### PR TITLE
Add citation file

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,24 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: Lubinski
+    given-names: Thomas
+  - family-names: Johri
+    given-names: Sonika
+  - family-names: Varosy
+    given-names: Paul
+  - family-names: Coleman
+    given-names: Jeremiah
+  - family-names: Zhao
+    given-names: Luning
+  - family-names: Necaise
+    given-names: Jason
+  - family-names: Baldwin
+    given-names: Charles
+  - family-names: Mayer
+    given-names: Karl
+  - family-names: Proctor
+    given-names: Timothy
+title: "Application-Oriented Performance Benchmarks for Quantum Computing"
+date-released: 2021-10-7
+url: "https://arxiv.org/abs/2110.03137"


### PR DESCRIPTION
Create a citation file which points users to arxiv paper if they want to cite it. This allows us to provide credit to the people who worked on the project before it went public. 

Follows the process outline [here](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-citation-files). We can modify this in the future by adding the ORCID codes for the authors, as well as by adding the journal where this ends up being published.