### PR TITLE
Add `CONTRIBUTING` file and `CODE_OF_CONDUCT` file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,133 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[INSERT CONTACT METHOD].
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+# How to Contribute
+
+We're extremely glad that you are looking to contribute to this suite of quantum benchmarks. We want this project to grow and thrive with community involvement, so we welcome any and all contributions! 
+
+First and foremost, please ensure through all interactions in this community you follow our [Code of Conduct](./CODE_OF_CONDUCT.md).
+
+## Submitting New Issues
+
+Please use the [Issues tab](https://github.com/SRI-International/QC-App-Oriented-Benchmarks/issues) for **both bugs and features**. For these two types of improvements, we have different processes.
+
+### Bug Reports
+
+- Make sure the bug doesn't already exist as an open issue.
+- If the bug hasn't been reported before, [open a new issue](https://github.com/SRI-International/QC-App-Oriented-Benchmarks/issues/new). Include a title, clear description with as much information as possible, and a code sample which demonstrates the un-desired behavior.
+
+### Feature Reports
+
+- If you have an suggested feature to the repository, include enough information about what is missing and, if possible, a suggestion for how to implement it.
+- Consider how this feature might fit in with existing projects and the goals of the project. Once submitted to the Issues tab, the members of the community and maintainers can provide feedback. 
+
+## Contributing Pull Requests
+
+For all GitHub pull requests to the project, clearly state what has been done (more information about [pull requests](https://docs.github.com/en/github/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-pull-requests)). Provide extensive information such that all of the changes are rationalized. 
+
+- If you found a bug and found a suggested fix, to add it to the repository, please make a pull request explaining the incorrect behavior and what was done to fix it.
+- Before working on a feauture, please submit the suggested feature into the Issues tab to get feedback on how the feature will fit in with the project. No one wants to spend time working on code that ends up not being implemented.
+
+## Coding Conventions
+
+We do not have any explict coding conventions currently. Please ensure that any suggested code improvements follow a somewhat similar style to the code that already exists.


### PR DESCRIPTION
Added two files for public github release. We need to add an email/contact information for code of conduct violations. **This PR should not be merged until we have found a way to address this**. We could create an email for the sole purpose of tracking any reports, but I don't know what would be the best way.

The contributing file is also a pretty rough sketch of how someone might contribute, but I am open to suggestions as to how we could potentially modify this file to be more in-line with better contribution ideas. Additionally, we can always update the contributions file as more people start using the repo.