### PR TITLE
Fixed `FileNotFoundError`

### DIFF
--- a/hamiltonian-simulation/braket/hamiltonian_simulation_benchmark.py
+++ b/hamiltonian-simulation/braket/hamiltonian_simulation_benchmark.py
@@ -3,11 +3,13 @@ Hamiltonian-Simulation Benchmark Program - Braket
 """
 
 import json
+import os
 import sys
 import time
 
-from braket.circuits import Circuit     # AWS imports: Import Braket SDK modules
 import numpy as np
+
+from braket.circuits import Circuit  # AWS imports: Import Braket SDK modules
 
 sys.path[1:1] = [ "_common", "_common/braket" ]
 sys.path[1:1] = [ "../../_common", "../../_common/braket" ]
@@ -26,10 +28,10 @@ QC_ = None
 _use_XX_YY_ZZ_gates = False
 
 # import precalculated data to compare against
-try:
-    precalculated_data = json.load(open('hamiltonian-simulation/_common/precalculated_data.json', 'r'))
-except:
-    precalculated_data = json.load(open('_common/precalculated_data.json', 'r'))
+filename = os.path.join(os.path.dirname(__file__), os.path.pardir, "_common", "precalculated_data.json")
+with open(filename, 'r') as file:
+    data = file.read()
+precalculated_data = json.loads(data)
 
 ############### Circuit Definition
 

--- a/hamiltonian-simulation/cirq/hamiltonian_simulation_benchmark.py
+++ b/hamiltonian-simulation/cirq/hamiltonian_simulation_benchmark.py
@@ -2,13 +2,15 @@
 Hamiltonian-Simulation Benchmark Program - Cirq
 """
 
-from collections import defaultdict
 import json
+import os
 import sys
 import time
+from collections import defaultdict
+
+import numpy as np
 
 import cirq
-import numpy as np
 
 sys.path[1:1] = ["_common", "_common/cirq"]
 sys.path[1:1] = ["../../_common", "../../_common/cirq"]
@@ -31,10 +33,10 @@ XXYYZZ_ = None
 _use_XX_YY_ZZ_gates = False
 
 # import precalculated data to compare against
-try:
-    precalculated_data = json.load(open('hamiltonian-simulation/_common/precalculated_data.json', 'r'))
-except:
-    precalculated_data = json.load(open('_common/precalculated_data.json', 'r'))
+filename = os.path.join(os.path.dirname(__file__), os.path.pardir, "_common", "precalculated_data.json")
+with open(filename, 'r') as file:
+    data = file.read()
+precalculated_data = json.loads(data)
 
 ############### Circuit Definition
 

--- a/hamiltonian-simulation/qiskit/hamiltonian_simulation_benchmark.py
+++ b/hamiltonian-simulation/qiskit/hamiltonian_simulation_benchmark.py
@@ -3,11 +3,13 @@ Hamiltonian-Simulation Benchmark Program - Qiskit
 """
 
 import json
+import os
 import sys
 import time
 
 import numpy as np
-from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
+
+from qiskit import ClassicalRegister, QuantumCircuit, QuantumRegister
 
 sys.path[1:1] = ["_common", "_common/qiskit"]
 sys.path[1:1] = ["../../_common", "../../_common/qiskit"]
@@ -29,10 +31,10 @@ XXYYZZ_ = None
 _use_XX_YY_ZZ_gates = False
 
 # import precalculated data to compare against
-try:
-    precalculated_data = json.load(open('hamiltonian-simulation/_common/precalculated_data.json', 'r'))
-except:
-    precalculated_data = json.load(open('_common/precalculated_data.json', 'r'))
+filename = os.path.join(os.path.dirname(__file__), os.path.pardir, "_common", "precalculated_data.json")
+with open(filename, 'r') as file:
+    data = file.read()
+precalculated_data = json.loads(data)
 
 ############### Circuit Definition
 


### PR DESCRIPTION
When running any of the Hamiltonian simulation benchmarks from the command line the user would get a `FileNotFoundError`. This was due to a incorrect path to the `precalculated_data.json` files. 

Using the same structure as in the `vqe` benchmark, that also uses precalculated data, I fixed the path issue. The Hamiltonian simulation benchmarks now work as expected when executed on both the command line and jupyter notebooks. 