### PR TITLE
Switched md headings to H2

### DIFF
--- a/benchmarks-braket.ipynb.template
+++ b/benchmarks-braket.ipynb.template
@@ -50,7 +50,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Deutsch-Jozsa"
+    "## Deutsch-Jozsa"
    ]
   },
   {
@@ -72,7 +72,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bernstein-Vazirani"
+    "## Bernstein-Vazirani"
    ]
   },
   {
@@ -94,7 +94,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Hidden Shift"
+    "## Hidden Shift"
    ]
   },
   {
@@ -116,14 +116,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Quantum Fourier Transform"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Method 1"
+    "## Quantum Fourier Transform - Method 1"
    ]
   },
   {
@@ -146,7 +139,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Method 2"
+    "## Quantum Fourier Transform - Method 2"
    ]
   },
   {
@@ -169,7 +162,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Grover"
+    "## Grover"
    ]
   },
   {
@@ -191,7 +184,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Phase Estimation"
+    "## Phase Estimation"
    ]
   },
   {
@@ -213,7 +206,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Hamiltonian Simulation"
+    "## Hamiltonian Simulation"
    ]
   },
   {

--- a/benchmarks-cirq.ipynb.template
+++ b/benchmarks-cirq.ipynb.template
@@ -31,7 +31,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Deutsch-Jozsa"
+    "## Deutsch-Jozsa"
    ]
   },
   {
@@ -53,7 +53,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bernstein-Vazirani"
+    "## Bernstein-Vazirani"
    ]
   },
   {
@@ -75,7 +75,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Hidden Shift"
+    "## Hidden Shift"
    ]
   },
   {
@@ -97,14 +97,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Quantum Fourier Transform"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Method 1"
+    "## Quantum Fourier Transform - Method 1"
    ]
   },
   {
@@ -127,7 +120,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Method 2"
+    "## Quantum Fourier Transform - Method 2"
    ]
   },
   {
@@ -150,7 +143,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Grover"
+    "## Grover"
    ]
   },
   {
@@ -172,7 +165,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Phase Estimation"
+    "## Phase Estimation"
    ]
   },
   {
@@ -194,7 +187,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Amplitude Estimation"
+    "## Amplitude Estimation"
    ]
   },
   {
@@ -216,7 +209,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Monte Carlo"
+    "## Monte Carlo"
    ]
   },
   {
@@ -238,7 +231,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Hamiltonian Simulation"
+    "## Hamiltonian Simulation"
    ]
   },
   {
@@ -261,14 +254,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Shor"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Method 1"
+    "## Shor - Method 1"
    ]
   },
   {
@@ -290,7 +276,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Method 2"
+    "## Shor - Method 2"
    ]
   },
   {
@@ -301,7 +287,6 @@
    },
    "outputs": [],
    "source": [
-    "#%run shors/cirq/shors_benchmark.py\n",
     "import sys\n",
     "sys.path.insert(1, \"shors/cirq\")\n",
     "import shors_benchmark\n",

--- a/benchmarks-qiskit.ipynb.template
+++ b/benchmarks-qiskit.ipynb.template
@@ -87,7 +87,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Deutsch-Jozsa"
+    "## Deutsch-Jozsa"
    ]
   },
   {
@@ -110,14 +110,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Bernstein-Vazirani"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Method 1"
+    "## Bernstein-Vazirani - Method 1"
    ]
   },
   {
@@ -139,7 +132,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Method 2"
+    "## Bernstein-Vazirani - Method 2"
    ]
   },
   {
@@ -163,7 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Hidden Shift"
+    "## Hidden Shift"
    ]
   },
   {
@@ -184,14 +177,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Quantum Fourier Transform"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Method 1"
+    "## Quantum Fourier Transform - Method 1"
    ]
   },
   {
@@ -213,7 +199,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Method 2"
+    "## Quantum Fourier Transform - Method 2"
    ]
   },
   {
@@ -235,7 +221,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Grover"
+    "## Grover"
    ]
   },
   {
@@ -256,7 +242,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Phase Estimation"
+    "## Phase Estimation"
    ]
   },
   {
@@ -277,7 +263,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Amplitude Estimation"
+    "## Amplitude Estimation"
    ]
   },
   {
@@ -298,7 +284,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Monte Carlo"
+    "## Monte Carlo"
    ]
   },
   {
@@ -319,7 +305,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Hamiltonian Simulation"
+    "## Hamiltonian Simulation"
    ]
   },
   {
@@ -341,7 +327,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# VQE"
+    "## VQE - Method 1"
    ]
   },
   {
@@ -364,14 +350,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Shor"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Method 1"
+    "## Shor - Method 1"
    ]
   },
   {
@@ -393,7 +372,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Method 2"
+    "## Shor - Method 2"
    ]
   },
   {


### PR DESCRIPTION
Reduced size of markdown headings and moved the method type into the same md cell as the benchmark title. 