### PR TITLE
Fixed `coupling_map` issue

### DIFF
--- a/_common/transformers/tket_optimiser.py
+++ b/_common/transformers/tket_optimiser.py
@@ -49,19 +49,20 @@ def high_optimisation(circuit:QuantumCircuit, backend:BaseBackend) -> list[Quant
 
     # Add noise aware placement and routing to pass list.
     coupling_map = backend.configuration().coupling_map
-    arch = Architecture(coupling_map)
-    passlist.append(
-        CXMappingPass(
-            arch,
-            NoiseAwarePlacement(
+    if coupling_map:
+        arch = Architecture(coupling_map)
+        passlist.append(
+            CXMappingPass(
                 arch,
-                averaged_errors["node_errors"],
-                averaged_errors["edge_errors"],
-                averaged_errors["readout_errors"],
-            ),
-            directed_cx=False,
+                NoiseAwarePlacement(
+                    arch,
+                    averaged_errors["node_errors"],
+                    averaged_errors["edge_errors"],
+                    averaged_errors["readout_errors"],
+                ),
+                directed_cx=False,
+            )
         )
-    )
 
     # Perform coupling map safe optimisation.
     passlist.extend([CliffordSimp(False), SynthesiseTket()])
@@ -101,19 +102,20 @@ def quick_optimisation(circuit:QuantumCircuit, backend:BaseBackend) -> list[Quan
 
     # Add noise aware placement and routing to pass list.
     coupling_map = backend.configuration().coupling_map
-    arch = Architecture(coupling_map)
-    passlist.append(
-        CXMappingPass(
-            arch,
-            NoiseAwarePlacement(
+    if coupling_map:
+        arch = Architecture(coupling_map)
+        passlist.append(
+            CXMappingPass(
                 arch,
-                averaged_errors["node_errors"],
-                averaged_errors["edge_errors"],
-                averaged_errors["readout_errors"],
-            ),
-            directed_cx=False,
+                NoiseAwarePlacement(
+                    arch,
+                    averaged_errors["node_errors"],
+                    averaged_errors["edge_errors"],
+                    averaged_errors["readout_errors"],
+                ),
+                directed_cx=False,
+            )
         )
-    )
 
     # Rebase to backend gate set and perform basic optimisation
     passlist.append(rebase_pass())


### PR DESCRIPTION
If backend is a simulator then `coupling_map=None` and results in the follow error:
```
File "_common/transformers/tket_optimiser.py", line 104, in quick_optimisation
    arch = Architecture(coupling_map)
TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. pytket._tket.architecture.Architecture(connections: List[Tuple[int, int]])
    2. pytket._tket.architecture.Architecture(connections: List[Tuple[pytket._tket.circuit.Node, pytket._tket.circuit.Node]])
```

Mentioning Daniel (@daniel-mills-cqc) so he can stay in the loop.
