### PR TITLE
Added functionality to load and plot using stored data from previous runs

### DIFF
--- a/_common/metrics.py
+++ b/_common/metrics.py
@@ -41,6 +41,8 @@ circuit_metrics = {  }
 circuit_metrics_detail = {  }    # for iterative algorithms
 circuit_metrics_detail_2 = {  }  # used to break down to 3rd dimension
 
+circuit_metrics_final_iter = {  } # used to store final results for the last circuit in iterative algorithms.
+
 group_metrics = { "groups": [],
     "avg_create_times": [], "avg_elapsed_times": [], "avg_exec_times": [], "avg_fidelities": [], "avg_hf_fidelities": [],
     "avg_depths": [], "avg_xis": [], "avg_tr_depths": [], "avg_tr_xis": [], "avg_tr_n2qs": [],
@@ -127,6 +129,7 @@ def init_metrics ():
     circuit_metrics.clear()
     circuit_metrics_detail.clear()
     circuit_metrics_detail_2.clear()
+    circuit_metrics_final_iter.clear()
     
     # create empty arrays for group metrics
     group_metrics["groups"] = []
@@ -169,15 +172,31 @@ def store_metric (group, circuit, metric, value):
         circuit_metrics[group] = { }
     if circuit not in circuit_metrics[group]:
         circuit_metrics[group][circuit] = { }
-    circuit_metrics[group][circuit][metric] = value
-    #print(f'{group} {circuit} {metric} -> {value}')
-    
+        
     # if the value is a dict, store each metric provided
     if type(value) is dict:
         for key in value:
-            store_metric(group, circuit, key, value[key])
+            # If you want to store multiple metrics in one go,
+            # then simply provide these in the form of a dictionary under the value input
+            # In this case, the metric input will be ignored
+            store_metric(group, circuit, key, value[key]) 
+    else:
+        circuit_metrics[group][circuit][metric] = value
+    #print(f'{group} {circuit} {metric} -> {value}')
+    
+    
 
-
+def store_props_final_iter(group, circuit, metric, value):
+    group = str(group)
+    circuit = str(circuit)
+    if group not in circuit_metrics_final_iter: circuit_metrics_final_iter[group] = {}
+    if circuit not in circuit_metrics_final_iter[group]: circuit_metrics_final_iter[group][circuit] = { }
+    if type(value) is dict:
+        for key in value:
+            store_props_final_iter(group, circuit, key, value[key])
+    else:
+        circuit_metrics_final_iter[group][circuit][metric] = value
+    
 # Aggregate metrics for a specific group, creating average across circuits in group
 def aggregate_metrics_for_group (group):
     group = str(group)

--- a/maxcut/qiskit/maxcut_benchmark.py
+++ b/maxcut/qiskit/maxcut_benchmark.py
@@ -748,7 +748,6 @@ def run (min_qubits=3, max_qubits=6, max_circuits=3, num_shots=100,
                 # Store also the final results, including (cuts, counts, sizes) as well as final values of 
                 metrics.store_props_final_iter(num_qubits, s_int, None, saved_result)
                 metrics.store_props_final_iter(num_qubits, s_int, 'converged_thetas_list', res.x.tolist())
-                print(metrics.circuit_metrics_final_iter)
                 ########################################################
                 ####### Save results of (circuit width, degree) combination
                 # Store the results obtained for the current values of num_qubits and i (i.e. degree)


### PR DESCRIPTION
- New sets of functions added to maxcut_benchmark
  - To use the new functionality, simply use load_data_and_plot(folder) from maxcut_benchmarks, where folder denotes the location where all the json files are located.
- Slight modifications to metrics.py 
   - Added (s) to x axis label
   - Within optgap plot code. New code to ensure that group_metrics_2 metrics are arranged in ascending order of circuit widths. (Note: circuit_metrics_detail_2.keys() may not necessarily be arranged in ascending order.)
- Instead of storing the final qiskit counts object, store the following values for the last iteration of each problem:
   - 'cuts', a list of measured bitstrigs
   - 'counts', a list of measurement counts
   - 'sizes', a list of corresponding cut sizes
- Also store the best cut value for each iteration (along with approx ratio, cvar ratio and max % ratio).


