### PR TITLE
Updated maxcut benchmark notebook

### DIFF
--- a/maxcut/qiskit/benchmarks-qiskit-add-maxcut.ipynb
+++ b/maxcut/qiskit/benchmarks-qiskit-add-maxcut.ipynb
@@ -63,6 +63,27 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Custom optimization options can be specified in this cell (below is an example)\n",
+    "\n",
+    "# # Add Qiskit pass manager as a custom 'transformer' method\n",
+    "# import _common.transformers.qiskit_passmgr as qiskit_passmgr\n",
+    "# exec_options = { \"optimization_level\":3, \"layout_method\":'sabre', \"routing_method\":'sabre', \"transformer\": qiskit_passmgr.do_transform }\n",
+    "\n",
+    "# # Example of TrueQ Randomized Compilation\n",
+    "# import _common.transformers.trueq_rc as trueq_rc\n",
+    "# exec_options = { \"optimization_level\":3, \"layout_method\":'sabre', \"routing_method\":'sabre', \"transformer\": trueq_rc.local_rc } \n",
+    "\n",
+    "# # Define a custom noise model to be used during execution\n",
+    "# import _common.custom.custom_qiskit_noise_model as custom_qiskit_noise_model\n",
+    "# exec_options = { \"noise_model\": custom_qiskit_noise_model.my_noise_model() }\n"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -125,7 +146,9 @@
     "    min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "    method=2, rounds=2, degree=3,\n",
     "    score_metric=score_metric,\n",
-    "    objective_func_type = objective_func_type\n",
+    "    objective_func_type = objective_func_type,\n",
+    "    backend_id=backend_id, provider_backend=provider_backend,\n",
+    "    hub=hub, group=group, project=project, exec_options=exec_options\n",
     ")"
    ]
   },
@@ -162,7 +185,9 @@
     "    min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "    method=2, rounds=2, degree=3, alpha = 0.1, N = 5,\n",
     "    objective_func_type = objective_func_type, do_fidelities = False,\n",
-    "    score_metric=score_metric, x_metric=x_metric, num_x_bins=15, max_iter=30\n",
+    "    score_metric=score_metric, x_metric=x_metric, num_x_bins=15, max_iter=30,\n",
+    "    backend_id=backend_id, provider_backend=provider_backend,\n",
+    "    hub=hub, group=group, project=project, exec_options=exec_options\n",
     ")"
    ]
   },
@@ -199,7 +224,9 @@
     "    min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "    method=2, rounds=2, degree=3, alpha = 0.1, N = 5,\n",
     "    score_metric=score_metric, x_metric=x_metric, num_x_bins=15, max_iter=30,\n",
-    "    objective_func_type = objective_func_type, do_fidelities = False\n",
+    "    objective_func_type = objective_func_type, do_fidelities = False,\n",
+    "    backend_id=backend_id, provider_backend=provider_backend,\n",
+    "    hub=hub, group=group, project=project, exec_options=exec_options\n",
     ")"
    ]
   },
@@ -361,7 +388,9 @@
     "            method=2, rounds=rounds, degree=3, thetas_array=thetas_array, parameterized= False,\n",
     "            score_metric=score_metric,            \n",
     "            objective_func_type = objective_func_type, do_fidelities = False,\n",
-    "            plot_results = False\n",
+    "            plot_results = False,\n",
+    "            backend_id=backend_id, provider_backend=provider_backend,\n",
+    "            hub=hub, group=group, project=project, exec_options=exec_options\n",
     "    )\n",
     "    finIterInd = max(list(metrics.circuit_metrics_detail_2[str(num_qubits)][3].keys()))\n",
     "    ar_array[restartInd] = metrics.circuit_metrics_detail_2[str(num_qubits)][3][finIterInd]['approx_ratio']\n"
@@ -388,13 +417,10 @@
   }
  ],
  "metadata": {
-  "interpreter": {
-   "hash": "4edcc741b34098d786431ef295201419a38b7eac01f02aac783a5df30157881b"
-  },
   "kernelspec": {
-   "display_name": "qiskit",
+   "display_name": "Python 3.10.4 ('QEDC-qiskit')",
    "language": "python",
-   "name": "qiskit"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -406,7 +432,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.10.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "4edcc741b34098d786431ef295201419a38b7eac01f02aac783a5df30157881b"
+   }
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
* Added second cell from `benchmarks-qiskit.ipynb` for consistency
* Added `backend_id`, `hub`, `group`, `project`, `provider_backend`, `exec_options` arguments to all `run` calls to support alternate backends.