### PR TITLE
fix qaoa bug: endianness issue

### DIFF
--- a/maxcut/qiskit/maxcut_benchmark.py
+++ b/maxcut/qiskit/maxcut_benchmark.py
@@ -132,7 +132,8 @@ def create_qaoa_circ_param(nqubits, edges, parameters):
         
         # problem unitary
         for i,j in edges:
-            qc.rzz(2 * par.gamma, i, j)
+            qc.rzz(- par.gamma, nqubits - i - 1, nqubits - j - 1)
+            # qc.rzz(2 * par.gamma, i, j)
 
         qc.barrier()
         

--- a/maxcut/qiskit/maxcut_benchmark.py
+++ b/maxcut/qiskit/maxcut_benchmark.py
@@ -54,8 +54,8 @@ def create_qaoa_circ(nqubits, edges, parameters):
         
         # problem unitary
         for i,j in edges:
-            qc.rzz(- par.gamma, i, j)
-            # qc.rzz(2 * par.gamma, i, j)
+            qc.rzz(- par.gamma, nqubits - i - 1, nqubits - j - 1)
+            # qc.rzz(- par.gamma, i, j)
 
         qc.barrier()
         


### PR DESCRIPTION
Qiskit measurement results are reported in a little-endian format. Previous benchmark version assumed a big-endian format, which resulted in incorrect results.
Instead of reversing the bitstrings everywhere, this fix simple defines the qaoa circuit as a "water image" of what it was before.