### PR TITLE
update benchmark

### DIFF
--- a/maxcut/qiskit/maxcut_benchmark.py
+++ b/maxcut/qiskit/maxcut_benchmark.py
@@ -25,18 +25,21 @@ import common
 import execute as ex
 import metrics as metrics
 
-
 logger = logging.getLogger(__name__)
 
 fname, _, ext = os.path.basename(__file__).partition(".")
-logging.basicConfig(
-    #filename=f"{fname}_{datetime.datetime.now().strftime('%y%m%d_%H%M%S')}.log",
-    filename=f"{fname}.log",
-    filemode='w',
-    #encoding='utf-8',
-    level=logging.INFO,
-    format='%(asctime)s %(name)s - %(levelname)s:%(message)s'
-)
+try:
+    logging.basicConfig(
+        # filename=f"{fname}_{datetime.datetime.now().strftime('%Y_%m_%d_%S')}.log",
+        filename=f"{fname}.log",
+        filemode='w',
+        encoding='utf-8',
+        level=logging.INFO,
+        format='%(asctime)s %(name)s - %(levelname)s:%(message)s'
+    )
+except Exception as e:
+    print(f'Exception {e} occured while configuring logger: bypassing logger config to prevent data loss')
+    pass
 
 np.random.seed(0)
 
@@ -142,7 +145,7 @@ def create_qaoa_circ_param(nqubits, edges, betas, gammas):
         qc.h(i)
 
     for beta, gamma in zip(betas, gammas):
-        #print(f"... par={par}  gamma, beta = {par.gamma} {par.beta}")
+        #print(f"... gamma, beta = {gammas}, {betas}")
         
         # problem unitary
         for i,j in edges:
@@ -653,7 +656,7 @@ def dump_to_json(parent_folder_save, num_qubits, s_int, iter_size_dist, iter_dis
 
 #%% Loading saved data (from json files)
 
-def load_data_and_plot(folder):
+def load_data_and_plot(folder, **kwargs):
     """
     The highest level function for loading stored data from a previous run
     and plotting optgaps and area metrics
@@ -663,7 +666,8 @@ def load_data_and_plot(folder):
     folder : string
         Directory where json files are saved.
     """
-    gen_prop = load_all_metrics(folder)
+    _gen_prop = load_all_metrics(folder)
+    gen_prop = {**_gen_prop, **kwargs}
     plot_results_from_data(**gen_prop)
 
 

--- a/maxcut/qiskit/maxcut_benchmark.py
+++ b/maxcut/qiskit/maxcut_benchmark.py
@@ -692,7 +692,7 @@ def load_all_metrics(folder):
     
     list_of_files = os.listdir(folder)
     width_degree_file_tuples = [(*get_width_degree_tuple_from_filename(fileName),fileName) 
-                           for (ind,fileName) in enumerate(list_of_files)] # list with elements that are tuples->(width,degree,filename)
+                           for (ind,fileName) in enumerate(list_of_files) if fileName.startswith('width')] # list with elements that are tuples->(width,degree,filename)
     
     width_degree_file_tuples = sorted(width_degree_file_tuples, key=lambda x:(x[0], x[1])) #sort first by width, and then by degree
     list_of_files = [tup[2] for tup in width_degree_file_tuples]

--- a/maxcut/qiskit/maxcut_runtime.ipynb
+++ b/maxcut/qiskit/maxcut_runtime.ipynb
@@ -16,7 +16,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 58,
+   "execution_count": null,
    "metadata": {
     "scrolled": true
    },
@@ -39,7 +39,7 @@
     "provider_backend = None\n",
     "exec_options = None\n",
     "\n",
-    "API_TOKEN = \"your_api_token\"\n",
+    "API_TOKEN = \"YOUR_API_TOKEN\"\n",
     "\n",
     "# # *** If using IBMQ hardware, run this once to authenticate\n",
     "# from qiskit import IBMQ\n",
@@ -77,7 +77,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -105,7 +105,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -116,12 +116,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Executing benchmark on Runtime Servers"
+    "### Preparing Instances"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 36,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -136,17 +136,24 @@
     "insts = {}\n",
     "\n",
     "for f in os.listdir(\"../_common/instances/\"):\n",
-    "    p = f\"/home/japanavi/SRI/pr/QC-App-Oriented-Benchmarks/maxcut/_common/instances/{f}\"\n",
+    "    p = os.path.join(\"..\", \"_common\", \"instances\", f\"{f}\")\n",
     "    k, _, _ = f.partition('.')\n",
     "    insts[k] = {'instance': None, 'sol': None}\n",
     "\n",
     "for f in os.listdir(\"../_common/instances/\"):\n",
-    "    p = f\"/home/japanavi/SRI/pr/QC-App-Oriented-Benchmarks/maxcut/_common/instances/{f}\"\n",
+    "    p = os.path.join(\"..\", \"_common\", \"instances\", f\"{f}\")\n",
     "    k, _, _ = f.partition('.')\n",
     "    if 'txt' in f:\n",
     "        insts[k]['instance'] = common.read_maxcut_instance(p)\n",
     "    if 'sol' in f:\n",
     "        insts[k]['sol'] = common.read_maxcut_solution(p)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Executing benchmark on Runtime Servers"
    ]
   },
   {
@@ -183,7 +190,12 @@
     "    \"rounds\": rounds,\n",
     "    \"max_iter\": max_iter,\n",
     "    \"parameterized\": parameterized,\n",
-    "    \"do_fidelities\": False\n",
+    "    \"do_fidelities\": False,\n",
+    "\n",
+    "    # To keep plots consistent\n",
+    "    \"hub\": hub,\n",
+    "    \"group\": group,\n",
+    "    \"project\": project\n",
     "}\n",
     "\n",
     "try:\n",
@@ -238,7 +250,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "retrieved_result = provider.runtime.job(job.job_id)\n",
+    "\n",
+    "from qiskit import IBMQ\n",
+    "IBMQ.load_account()\n",
+    "\n",
+    "provider = IBMQ.get_provider(hub=hub, group=group, project=project)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "retrieved_result = provider.runtime.job(\"cc8lvjan6sj4pjbc5ac0\")\n",
     "result = retrieved_result.result()"
    ]
   },
@@ -260,11 +285,19 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
+    "import maxcut_benchmark\n",
     "maxcut_benchmark.load_data_and_plot('__data')"
    ]
   }


### PR DESCRIPTION
* Replaced hard coded paths with relative ones when generating instance dict for runtime
* Put logger.basicConfig in try except block so we will always run benchmarks without error on hardware
   - This will always cause an exception on runtime since we don't have access to a file system and basicConfig wants to write to a file.

* Fixed plotting issue by passing the hub, group, and project as runtime inputs.
* Added ability to specify keyword arguments in load_data_and_plot
     - e.g.: maxcut_benchmark.load_data_and_plot('__data', score_metric='approx_ratio') will now work, along with any other keyword argument.