### PR TITLE
Added Job Handling to Runtime

### DIFF
--- a/maxcut/qiskit/maxcut_benchmark.py
+++ b/maxcut/qiskit/maxcut_benchmark.py
@@ -1301,4 +1301,4 @@ def plot_results_from_data(num_shots=100, rounds=1, degree=3, max_iter=30, max_c
     metrics.plot_angles_polar(suptitle = suptitle, options = options, suffix = suffix)
 
 # if main, execute method
-if __name__ == '__main__': run(method=2)
+if __name__ == '__main__': run()

--- a/maxcut/qiskit/maxcut_benchmark.py
+++ b/maxcut/qiskit/maxcut_benchmark.py
@@ -801,7 +801,7 @@ def load_all_metrics(folder):
     
     list_of_files = os.listdir(folder)
     width_restart_file_tuples = [(*get_width_restart_tuple_from_filename(fileName), fileName)
-                                 for (ind, fileName) in enumerate(list_of_files)]  # list with elements that are tuples->(width,restartInd,filename)
+                                 for (ind, fileName) in enumerate(list_of_files) if fileName.startswith("width")]  # list with elements that are tuples->(width,restartInd,filename)
 
     width_restart_file_tuples = sorted(width_restart_file_tuples, key=lambda x:(x[0], x[1])) #sort first by width, and then by restartInd
     distinct_widths = list(set(it[0] for it in width_restart_file_tuples)) 
@@ -898,7 +898,7 @@ def get_width_restart_tuple_from_filename(fileName):
     pattern = 'width_([0-9]+)_restartInd_([0-9]+).json'
     match = re.search(pattern, fileName)
 
-    assert match is not None, f"File {fileName} found inside folder. All files inside specified folder must be named in the format 'width_int_restartInd_int.json"
+    # assert match is not None, f"File {fileName} found inside folder. All files inside specified folder must be named in the format 'width_int_restartInd_int.json"
     num_qubits = int(match.groups()[0])
     degree = int(match.groups()[1])
     return (num_qubits,degree)
@@ -1301,4 +1301,4 @@ def plot_results_from_data(num_shots=100, rounds=1, degree=3, max_iter=30, max_c
     metrics.plot_angles_polar(suptitle = suptitle, options = options, suffix = suffix)
 
 # if main, execute method
-if __name__ == '__main__': run()
+if __name__ == '__main__': run(method=2)

--- a/maxcut/qiskit/maxcut_runtime3.ipynb
+++ b/maxcut/qiskit/maxcut_runtime3.ipynb
@@ -1,0 +1,119 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Maxcut Runtime"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "min_qubits=4\n",
+    "max_qubits=4\n",
+    "max_circuits=1\n",
+    "num_shots=5000\n",
+    "\n",
+    "degree = 3\n",
+    "rounds = 2\n",
+    "max_iter = 30\n",
+    "parameterized = False\n",
+    "\n",
+    "max_execution_time = 100_000 # seconds\n",
+    "\n",
+    "backend_id=\"ibmq_qasm_simulator\"\n",
+    "hub=\"ibm-q-research\"; group=\"quantum-circ-1\"; project=\"main\"\n",
+    "provider_backend = None\n",
+    "exec_options = None\n",
+    "\n",
+    "import uuid\n",
+    "\n",
+    "# Meta data required by qiskit runtime\n",
+    "meta = {\n",
+    "  \"name\": f\"qedc-maxcut-benchmark-{uuid.uuid4()}\",\n",
+    "  \"description\": \"A sample Maxcut Benchmark program.\",\n",
+    "  \"max_execution_time\": 100_000,\n",
+    "  \"version\": \"1.0\",\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import runtime_utils\n",
+    "insts = runtime_utils.prepare_instances()\n",
+    "\n",
+    "job = runtime_utils.run(\n",
+    "    min_qubits=min_qubits,\n",
+    "    max_qubits=max_qubits,\n",
+    "    max_circuits=max_circuits,\n",
+    "    num_shots=num_shots,\n",
+    "    _instances=insts,\n",
+    "    degree=degree,\n",
+    "    rounds=rounds,\n",
+    "    max_iter=max_iter,\n",
+    "    parameterized=parameterized,\n",
+    "    max_execution_time=max_execution_time,\n",
+    "    backend_id=backend_id,\n",
+    "    hub=hub,\n",
+    "    group=group,\n",
+    "    project=project,\n",
+    "    meta=meta\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Plot from Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import os\n",
+    "import maxcut_benchmark\n",
+    "maxcut_benchmark.load_data_and_plot(os.path.join('__data', backend_id))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.10.4 ('QEDC-qiskit')",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.4"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "4edcc741b34098d786431ef295201419a38b7eac01f02aac783a5df30157881b"
+   }
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
After submitting a job to runtime a file will be created with the job id and status of that job. If the user tries to run on that same backend again it will prompt user on if they want to overwrite their data. If yes then it will submit a new job, if no, it will wait for previously submitted job to finish and save/plot the results.

Had to remove an assertion put in by Pratik. It asserted that all files within a backend directory must start with `width`. This will not work with this implementation because the job file will also be stored in the backend directory. 