### PR TITLE
optgaps plot improvements; changes to notebook

### DIFF
--- a/_common/metrics.py
+++ b/_common/metrics.py
@@ -1849,7 +1849,13 @@ def plot_cutsize_distribution(suptitle="Circuit Width (Number of Qubits)",
                 unique_counts = circuit_metrics_final_iter[group][restart_ind]['unique_counts']
                 unique_sizes = circuit_metrics_final_iter[group][restart_ind]['unique_sizes']
                 optimal_value = circuit_metrics_final_iter[group][restart_ind]['optimal_value']
-                axs.plot(np.array(unique_sizes) / optimal_value, np.array(unique_counts) / sum(unique_counts), marker='o',
+                
+                sizes_array = np.arange(optimal_value + 1)
+                counts_array = [unique_counts[unique_sizes.index(s)] if s in unique_sizes else 0 for s in sizes_array]
+                counts_array = np.array(counts_array)
+
+
+                axs.plot(sizes_array / optimal_value, counts_array / np.sum(counts_array), marker='o',
                          ls = '-', c = colors[list_of_widths.index(group)], ms=2, mec = 'k', mew=0.2,
                          label = f"From QAOA. Width={group}")#" degree={deg}") # lw=1,
                 
@@ -1857,7 +1863,12 @@ def plot_cutsize_distribution(suptitle="Circuit Width (Number of Qubits)",
                 unique_counts_unif = circuit_metrics_final_iter[group][restart_ind]['unique_counts_unif']
                 unique_sizes_unif = circuit_metrics_final_iter[group][restart_ind]['unique_sizes_unif']
                 optimal_value = circuit_metrics_final_iter[group][restart_ind]['optimal_value']
-                axs.plot(np.array(unique_sizes_unif) / optimal_value, np.array(unique_counts_unif) / sum(unique_counts_unif),
+                
+                sizes_array = np.arange(optimal_value + 1)
+                unif_counts_array = [unique_counts_unif[unique_sizes_unif.index(s)] if s in unique_sizes_unif else 0 for s in sizes_array]
+                unif_counts_array = np.array(unif_counts_array)
+                
+                axs.plot(sizes_array / optimal_value, unif_counts_array / np.sum(unif_counts_array),
                          marker='o', c = colors[list_of_widths.index(group)], ms=1, mec = 'k',mew=0.2,
                          ls = 'dotted', label = f"Uniform Sampling. Width={group}")#" degree={deg}") # lw=1,
                 
@@ -2015,11 +2026,11 @@ def plot_metrics_optgaps (suptitle="Circuit Width (Number of Qubits)",
             mets = circuit_metrics_detail_2[group][circuit_id][last_ind]
             
             # Compute optimality gaps for the objective function types
-            group_metrics_optgaps['approx_ratio']['gapvals'].append((1.0 - mets["approx_ratio"]) * 100)
-            group_metrics_optgaps['Max_N_approx_ratio']['gapvals'].append((1.0 - mets["Max_N_approx_ratio"]) * 100)
-            group_metrics_optgaps['cvar_approx_ratio']['gapvals'].append((1.0 - mets["cvar_approx_ratio"]) * 100)
-            group_metrics_optgaps['bestCut_approx_ratio']['gapvals'].append((1.0 - mets["bestCut_approx_ratio"]) * 100)
-            group_metrics_optgaps['gibbs_ratio']['gapvals'].append((1.0 - mets["gibbs_ratio"]) * 100)
+            group_metrics_optgaps['approx_ratio']['gapvals'].append(abs(1.0 - mets["approx_ratio"]) * 100)
+            group_metrics_optgaps['Max_N_approx_ratio']['gapvals'].append(abs(1.0 - mets["Max_N_approx_ratio"]) * 100)
+            group_metrics_optgaps['cvar_approx_ratio']['gapvals'].append(abs(1.0 - mets["cvar_approx_ratio"]) * 100)
+            group_metrics_optgaps['bestCut_approx_ratio']['gapvals'].append(abs(1.0 - mets["bestCut_approx_ratio"]) * 100)
+            group_metrics_optgaps['gibbs_ratio']['gapvals'].append(abs(1.0 - mets["gibbs_ratio"]) * 100)
 
             # Also store the optimality gaps at the three quantiles values
             # Here, optgaps are defined as weight(cut)/weight(maxcut) * 100
@@ -2144,7 +2155,7 @@ def plot_metrics_optgaps (suptitle="Circuit Width (Number of Qubits)",
         ideal_lgnd_seq = ['approx_ratio', 'Max_N_approx_ratio', 'cvar_approx_ratio', 'gibbs_ratio', 'bestCut_approx_ratio', 'quantile_optgaps']
         handles_list= [plt_handles[s] for s in ideal_lgnd_seq if s in plt_handles]
         axs.legend(handles=handles_list, loc='center left', bbox_to_anchor=(1, 0.5)) # For now, we are only plotting for degree 3, and not -3
-        axs.set_ylim([0, 60])
+        axs.set_ylim(bottom=0,top=100)
 
         # Add grid
         plt.grid()

--- a/maxcut/qiskit/benchmarks-qiskit-add-maxcut.ipynb
+++ b/maxcut/qiskit/benchmarks-qiskit-add-maxcut.ipynb
@@ -19,7 +19,7 @@
    "outputs": [],
    "source": [
     "min_qubits=4\n",
-    "max_qubits=4\n",
+    "max_qubits=8\n",
     "max_circuits=1\n",
     "num_shots=5000\n",
     "\n",
@@ -118,7 +118,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Maxcut - Method 2 - Degree 3 - Average method"
+    "### Maxcut - Method 2 - Degree 3 - Energy Expectation as Objective Function"
    ]
   },
   {
@@ -156,46 +156,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Maxcut - Method 2 - Degree 3 - Max method"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"maxcut/qiskit\")\n",
-    "import maxcut_benchmark\n",
-    "\n",
-    "# set noise to None for testing\n",
-    "import execute\n",
-    "execute.set_noise_model(None)\n",
-    "\n",
-    "objective_func_type = 'Max_N_approx_ratio'\n",
-    "score_metric=[objective_func_type]\n",
-    "x_metric=['cumulative_exec_time']\n",
-    "\n",
-    "# Note: the plots produced by this benchmark only use the last of the problems at each width\n",
-    "\n",
-    "maxcut_benchmark.run(\n",
-    "    min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
-    "    method=2, rounds=2, degree=3, alpha = 0.1, N = 5,\n",
-    "    objective_func_type = objective_func_type, do_fidelities = False,\n",
-    "    score_metric=score_metric, x_metric=x_metric, num_x_bins=15, max_iter=30,\n",
-    "    backend_id=backend_id, provider_backend=provider_backend,\n",
-    "    hub=hub, group=group, project=project, exec_options=exec_options\n",
-    ")"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Maxcut - Method 2 - Degree 3 - CVaR"
+    "### Maxcut - Method 2 - Degree 3 - CVaR Objective Function"
    ]
   },
   {
@@ -215,6 +176,45 @@
     "execute.set_noise_model(None)\n",
     "\n",
     "objective_func_type = 'cvar_approx_ratio'\n",
+    "score_metric=[objective_func_type]\n",
+    "x_metric=['cumulative_exec_time']\n",
+    "\n",
+    "# Note: the plots produced by this benchmark only use the last of the problems at each width\n",
+    "\n",
+    "maxcut_benchmark.run(\n",
+    "    min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
+    "    method=2, rounds=2, degree=3, alpha = 0.1,\n",
+    "    objective_func_type = objective_func_type, do_fidelities = False,\n",
+    "    score_metric=score_metric, x_metric=x_metric, num_x_bins=15, max_iter=30,\n",
+    "    backend_id=backend_id, provider_backend=provider_backend,\n",
+    "    hub=hub, group=group, project=project, exec_options=exec_options\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Maxcut - Method 2 - Degree 3 - Gibbs Objective function"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "import sys\n",
+    "sys.path.insert(1, \"maxcut/qiskit\")\n",
+    "import maxcut_benchmark\n",
+    "\n",
+    "# set noise to None for testing\n",
+    "import execute\n",
+    "execute.set_noise_model(None)\n",
+    "\n",
+    "objective_func_type = 'gibbs_ratio'\n",
     "score_metric=[objective_func_type] #, 'fidelity'\n",
     "x_metric=['cumulative_exec_time'] #, , 'cumulative_create_time' 'cumulative_opt_exec_time'\n",
     "\n",
@@ -222,7 +222,7 @@
     "\n",
     "maxcut_benchmark.run(\n",
     "    min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
-    "    method=2, rounds=2, degree=3, alpha = 0.1, N = 5,\n",
+    "    method=2, rounds=2, degree=3, eta=0.5,\n",
     "    score_metric=score_metric, x_metric=x_metric, num_x_bins=15, max_iter=30,\n",
     "    objective_func_type = objective_func_type, do_fidelities = False,\n",
     "    backend_id=backend_id, provider_backend=provider_backend,\n",
@@ -337,76 +337,11 @@
     "from qiskit.visualization import plot_histogram\n",
     "plot_histogram(counts)\n"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "## Random Restarts\n",
-    "Choose 100 random initial parameters and plot the approximation ratios"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import numpy as np\n",
-    "np.random.seed(0)\n",
-    "\n",
-    "import metrics\n",
-    "restarts = 25\n",
-    "rounds = 2\n",
-    "num_qubits = 4\n",
-    "\n",
-    "# Define initial angles\n",
-    "_min = [0] * 2 * rounds\n",
-    "_max = [np.pi] * 2 * rounds\n",
-    "thetas = np.random.uniform(low=_min, high=_max, size=(restarts, 2 * rounds))\n",
-    "objective_func_type = 'approx_ratio'\n",
-    "score_metric=[objective_func_type]\n",
-    "\n",
-    "ar_array = np.zeros(restarts)\n",
-    "\n",
-    "for restartInd in range(restarts):\n",
-    "    thetas_array = thetas[restartInd, :].tolist()\n",
-    "    maxcut_benchmark.run(\n",
-    "            min_qubits=num_qubits, max_qubits=num_qubits, max_circuits=1, num_shots=num_shots,\n",
-    "            method=2, rounds=rounds, degree=3, thetas_array=thetas_array, parameterized= False,\n",
-    "            score_metric=score_metric,            \n",
-    "            objective_func_type = objective_func_type, do_fidelities = False,\n",
-    "            plot_results = False,\n",
-    "            backend_id=backend_id, provider_backend=provider_backend,\n",
-    "            hub=hub, group=group, project=project, exec_options=exec_options\n",
-    "    )\n",
-    "    finIterInd = max(list(metrics.circuit_metrics_detail_2[str(num_qubits)][3].keys()))\n",
-    "    ar_array[restartInd] = metrics.circuit_metrics_detail_2[str(num_qubits)][3][finIterInd]['approx_ratio']\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import matplotlib.pyplot as plt\n",
-    "import os\n",
-    "fig, ax = plt.subplots()\n",
-    "ax.plot([i for i in range(restarts)], ar_array, 'o')\n",
-    "ax.set_xlabel(\"Restart number\")\n",
-    "ax.set_ylabel(\"Approximation Ratio\")\n",
-    "# _ = ax.set_xticks([i for i in range(restarts)], labels=[str(i) for i in range(restarts)])\n",
-    "if not os.path.exists(\"__images\"): os.mkdir(\"__images\")\n",
-    "fileName = os.path.join(\"__images\", \"restarts_rounds-{}_qubits={}\".format(rounds, num_qubits))\n",
-    "plt.savefig(fileName + '.png')\n",
-    "plt.savefig(fileName + '.pdf')\n"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.10.6",
+   "display_name": "Python 3.9.12 ('qiskit')",
    "language": "python",
    "name": "python3"
   },
@@ -420,11 +355,11 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.6"
+   "version": "3.9.12"
   },
   "vscode": {
    "interpreter": {
-    "hash": "e44408ae64f08698421cfee029c293cdd741178aaeb7c68f0d4d3b424bf56322"
+    "hash": "7790cfd6e3291e78bfed432bf4f0dd82e23c049c36660468198d02b075b1b857"
    }
   }
  },


### PR DESCRIPTION
- Detailed optgaps: put abs(....) for every objective function while plotting optgaps. (Sometimes some of the metrics have optgap values of "-0.0", which used to interpreted by matplotlib as being negative and hence not shown by on the plot. This will not happen now)
- cut size distributions will not skip over cut sizes with 0 counts.
- ylim changed back to 0 to 100 for detailed optgaps, since some of the metrics do have large values especially at smaller graph sizes.
- Parameter changes in notebook.
- Replaced maxn by gibbs cells.
- Removed restarts cell in notebook, since it was outdated, and the latest code is now in 