### PR TITLE
adding BlueQubit-CPU and BlueQubit-GPU as backends

### DIFF
--- a/quantum-fourier-transform/cirq/qft_benchmark.py
+++ b/quantum-fourier-transform/cirq/qft_benchmark.py
@@ -1,7 +1,6 @@
 """
 Quantum Fourier Transform Benchmark Program - Cirq
 """
-
 from collections import defaultdict
 import math
 import sys
@@ -198,14 +197,17 @@ def expected_dist(num_qubits, secret_int, counts):
 # Expected result is always the secret_int, so fidelity calc is simple
 def analyze_and_print_result (qc, result, num_qubits, secret_int, num_shots, method):
     
-    # get measurement array and shot count
-    measurements = result.measurements['result']
-    num_shots = len(measurements)
+    if hasattr(result, 'counts'):
+        counts = result.counts
+    else:
+        # get measurement array and shot count
+        measurements = result.measurements['result']
+        num_shots = len(measurements)
 
-    # create counts distribution
-    counts = defaultdict(lambda: 0)
-    for row in measurements:
-        counts["".join([str(x) for x in reversed(row)])] += 1
+        # create counts distribution
+        counts = defaultdict(lambda: 0)
+        for row in measurements:
+            counts["".join([str(x) for x in reversed(row)])] += 1
         
     # For method 1, expected result is always the secret_int
     if method==1:
@@ -335,4 +337,4 @@ def run (min_qubits = 2, max_qubits = 8, max_circuits = 3, num_shots=100,
     metrics.plot_metrics("Benchmark Results - Quantum Fourier Transform - Cirq")
 
 # if main, execute method    
-if __name__ == '__main__': run()
+if __name__ == '__main__': run(18, 20, backend_id='BlueQubit-CPU')


### PR DESCRIPTION
Now QED-C algo benchmarks can be run on BlueQubit's souped-up CPUs and GPUs by providing the corresponding backend name:
```
run(18, 20, backend_id='BlueQubit-CPU' # for CPUs
run(18, 20, backend_id='BlueQubit-GPU' # for GPUs
```
Note*. I have left a bluequbit token in the [_common/cirq/execute.py:88](https://github.com/SRI-International/QC-App-Oriented-Benchmarks/compare/master...hthayko:QC-App-Oriented-Benchmarks:master#diff-f5327a4904acb63c39c6ebf7212061f739265a3b35cf35c2dc81683e8cd7cbfbR88), bad practice - but that will let you get running right away. It's a good idea to create a separate token by opening an account at app.bluequbit.io