### PR TITLE
Change hydrogen lattice plot_layout_style to 'grid' default

### DIFF
--- a/hydrogen-lattice/qiskit/benchmarks-qiskit-hydrogen-lattice.ipynb
+++ b/hydrogen-lattice/qiskit/benchmarks-qiskit-hydrogen-lattice.ipynb
@@ -166,7 +166,7 @@
     "    # display options for line plots (pairwise)\n",
     "    line_y_metrics=['energy', 'solution_quality_error'],           # + 'solution_quality', 'accuracy_ratio', 'accuracy_ratio_error'\n",
     "    line_x_metrics=['iteration_count', 'cumulative_exec_time'],    # + 'cumulative_elapsed_time'\n",
-    "    plot_layout_style='stacked',                                   # plot layout, can be 'grid', 'stacked', or 'individual'\n",
+    "    plot_layout_style='grid',                                      # plot layout, can be 'grid', 'stacked', or 'individual'\n",
     "    \n",
     "    # display options for area plots (multiplicative)\n",
     "    score_metric=['solution_quality', 'accuracy_ratio'],\n",


### PR DESCRIPTION
Note!  The name of the main notebook in the hydrogen lattice folder has changed