### PR TITLE
For area plots, remove exceedingly long initial elapsed times

### DIFF
--- a/hydrogen-lattice/qiskit/hydrogen_lattice_benchmark.py
+++ b/hydrogen-lattice/qiskit/hydrogen_lattice_benchmark.py
@@ -1351,7 +1351,6 @@ def run(
                 ex.set_tranpilation_flags(do_transpile_metrics=True, do_transpile_for_execute=True)
 
                 # get the classically computed expected energy variables from solution object
-                hf_energy = float(next(value for key, value in solution if key == "hf_energy"))
                 doci_energy = float(next(value for key, value in solution if key == "doci_energy"))
                 fci_energy = float(next(value for key, value in solution if key == "fci_energy"))
                 hf_energy = float(next(value for key, value in solution if key == "hf_energy"))


### PR DESCRIPTION
(probably due to queue time)
Remove later, if we get rid of queue times early