### PR TITLE
Improvements to metrics bar plot and IBM Sampler exec time

### DIFF
--- a/_common/metrics.py
+++ b/_common/metrics.py
@@ -76,7 +76,10 @@ save_plot_images = True
 show_plot_images = True
 
 # Option to show elapsed times in the metrics plots
-show_elapsed_times = False
+show_elapsed_times = True
+
+# When ratio of max time to min time exceeds this use a logscale
+logscale_for_times_threshold = 50
 
 # Option to generate volumetric positioning charts
 do_volumetric_plots = True
@@ -1024,7 +1027,7 @@ def plot_metrics (suptitle="Circuit Width (Number of Qubits)", transform_qubit_g
             if max(avg_exec_times) < 0.1:
                 axs[axi].set_ylim([0, 0.1])
             
-        axs[axi].bar(groups, avg_exec_times, zorder = 3)
+        axs[axi].bar(groups, avg_exec_times, 0.55 if show_elapsed_times is True else 0.7, zorder = 3)
         axs[axi].set_ylabel('Avg Execution Time (sec)')
         
         # error bars
@@ -1054,7 +1057,6 @@ def plot_metrics (suptitle="Circuit Width (Number of Qubits)", transform_qubit_g
         # optional log axis processing
         
         use_logscale_for_times = False
-        logscale_for_times_threshold = 50
         
         # determine min and max of both data sets, with a lower limit of 0.1
         y_max_0 = max(avg_exec_times)
@@ -1078,7 +1080,7 @@ def plot_metrics (suptitle="Circuit Width (Number of Qubits)", transform_qubit_g
         # print(f"{y_min_0} {y_max_0}")
         
         # force use of logscale if total range ratio above the threshold
-        if y_max_0 / y_min_0 > logscale_for_times_threshold:
+        if logscale_for_times_threshold > 0 and y_max_0 / y_min_0 > logscale_for_times_threshold:
             use_logscale_for_times = True
             
         # set up log scale if specified
@@ -1140,7 +1142,7 @@ def plot_metrics (suptitle="Circuit Width (Number of Qubits)", transform_qubit_g
             
         # data bars
         axs[axi].bar(groups, avg_hf_fidelities, color='skyblue', alpha = 0.8, zorder = 3)
-        axs[axi].bar(groups, avg_fidelities, 0.5, zorder = 3) 
+        axs[axi].bar(groups, avg_fidelities, 0.55, zorder = 3) 
         
         # error bars
         axs[axi].errorbar(groups, avg_fidelities, yerr=std_fidelities,

--- a/_common/metrics.py
+++ b/_common/metrics.py
@@ -76,7 +76,7 @@ save_plot_images = True
 show_plot_images = True
 
 # Option to show elapsed times in the metrics plots
-show_elapsed_times = True
+show_elapsed_times = False
 
 # When ratio of max time to min time exceeds this use a logscale
 logscale_for_times_threshold = 50

--- a/_common/metrics.py
+++ b/_common/metrics.py
@@ -981,8 +981,58 @@ def plot_metrics (suptitle="Circuit Width (Number of Qubits)", transform_qubit_g
         if show_elapsed_times:
             axs[axi].legend(['Elapsed', 'Quantum'], loc='upper left')
         #else:
-            #axs[axi].legend(['Quantum'], loc='upper left')
+            #axs[axi].legend(['Quantum'], loc='upper left') 
+        
+        ###################################
+        # optional log axis processing
+        
+        use_logscale_for_times = False
+        logscale_for_times_threshold = 50
+        
+        # determine min and max of both data sets, with a lower limit of 0.1
+        y_max_0 = max(avg_exec_times)
+        y_max_0 = max(0.10, y_max_0)
+        
+        # for min, assume 0.001 is the minimum, in case it is 0
+        y_min_0 = min(filter(lambda x: x > 0, avg_exec_times))
+
+        if show_elapsed_times:
+            y_max_0 = max(y_max_0, max(avg_elapsed_times))
+            y_min_0 = min(y_min_0, min(filter(lambda x: x > 0, avg_elapsed_times)))
+        
+        # make just a little larger for autoscaling
+        y_max_0 *= 1.1                
+        y_min_0 = y_min_0 / 1.1
+        
+        # for min, assume 0.001 is the minimum, in case it is 0
+        if y_min_0 <= 0:
+            y_min_0 = 0.001
+        
+        # print(f"{y_min_0} {y_max_0}")
+        
+        # force use of logscale if total range ratio above the threshold
+        if y_max_0 / y_min_0 > logscale_for_times_threshold:
+            use_logscale_for_times = True
             
+        # set up log scale if specified
+        if use_logscale_for_times:
+            axs[axi].set_yscale('log') 
+            
+            #if y_max_0 > 0.01:
+            y_max_0 *= 1.6
+            y_min_0 /= 1.6
+            
+            if y_max_0 / y_min_0 < logscale_for_times_threshold:
+                y_min_0 = y_max_0 / logscale_for_times_threshold
+        
+        # always start at 0 if not log scale
+        else:
+            y_min_0 = 0
+        
+        # set full range of the y-axis
+        # print(f"{y_min_0} {y_max_0}")
+        axs[axi].set_ylim([y_min_0, y_max_0])
+        
         # none of these methods of sharing the x axis gives proper effect; makes extra white space
         #axs[axi].sharex(axs[2])
         #plt.setp(axs[axi].get_xticklabels(), visible=False)

--- a/_common/qiskit/execute.py
+++ b/_common/qiskit/execute.py
@@ -53,7 +53,7 @@ from qiskit.providers.aer.noise import depolarizing_error, reset_error
 #### these variables are currently accessed as globals from user code
 
 # maximum number of active jobs
-max_jobs_active = 5
+max_jobs_active = 3
 
 # job mode: False = wait, True = submit multiple jobs
 job_mode = False

--- a/_common/qiskit/execute.py
+++ b/_common/qiskit/execute.py
@@ -1181,7 +1181,10 @@ def process_step_times(job, result, active_circuit):
 
     # when sessions and sampler used, we obtain metrics differently
     if use_sessions:
-        job_timestamps= job.metrics()['timestamps']
+        job_timestamps = job.metrics()['timestamps']
+        job_metrics = job.metrics()
+        # print(f"... usage = {job_metrics['usage']} {job_metrics['executions']}")
+        
         if verbose:
             print(f"... job.metrics() = {job.metrics()}")
             print(f"... job.result().metadata[0] = {result.metadata[0]}")
@@ -1203,12 +1206,21 @@ def process_step_times(job, result, active_circuit):
             exec_validating_time = 0.001
             exec_queued_time = 0.001
             
+            # when using sessions, the 'running_time' is the 'quantum exec time' - override it here.
+            metrics.store_metric(active_circuit["group"], active_circuit["circuit"], 'exec_time', exec_running_time)
+            
+            # use the data in usage field if it is returned, usually by hardware
+            # here we use the executions field to indicate we are on hardware
+            if "usage" in job_metrics and "executions" in job_metrics:
+                if job_metrics['executions'] > 0:
+                    exec_time = job_metrics['usage']['quantum_seconds'] 
+                    
+                    # and use this one as it seems to be valid for this case
+                    metrics.store_metric(active_circuit["group"], active_circuit["circuit"], 'exec_time', exec_time)
+            
             # DEVNOTE: we do not compute this yet
             # exec_quantum_classical_time = job.metrics()['bss']
-            #metrics.store_metric(active_circuit["group"], active_circuit["circuit"], 'exec_quantum_classical_time', exec_quantum_classical_time)
-            
-            # when using sessions, the 'running_time' is the 'quantum exec time' - override it.
-            metrics.store_metric(active_circuit["group"], active_circuit["circuit"], 'exec_time', exec_running_time)
+            # metrics.store_metric(active_circuit["group"], active_circuit["circuit"], 'exec_quantum_classical_time', exec_quantum_classical_time)     
         
         except Exception as e:
             if verbose:


### PR DESCRIPTION
We now switch to log scale at a certain range
For IBM Sampler executions, use quantum_seconds for the execution time.