### PR TITLE
Changes to qiskit/execute.py to support IBM Cloud

### DIFF
--- a/_common/qiskit/execute.py
+++ b/_common/qiskit/execute.py
@@ -76,7 +76,10 @@ session_count = 0
 session = None
 sampler = None
 
-# IBM-Q Service save here if created
+# Use the IBM Quantum Platform system; default is to use the new IBM Cloud
+use_ibm_quantum_platform = False
+
+# IBM Quantum Service save here if created
 service = None
 
 # Azure Quantum Provider saved here if created
@@ -299,6 +302,8 @@ def set_execution_target(backend_id='qasm_simulator',
 
     # otherwise use the given providername or backend_id to find the backend
     else:
+        global service
+        global sampler
     
         # if provider_module name and provider_name are provided, obtain a custom provider
         if provider_module_name and provider_name:  
@@ -350,8 +355,10 @@ def set_execution_target(backend_id='qasm_simulator',
                     
             backend.latest_session = session
             
-        # otherwise, assume the backend_id is given only and assume it is IBMQ device
-        else:
+        ###############################
+        # if using IBM Quantum Platform, assume the backend_id is given only
+        elif use_ibm_quantum_platform: 
+        
             from qiskit import IBMQ
             if IBMQ.stored_account():
             
@@ -366,8 +373,6 @@ def set_execution_target(backend_id='qasm_simulator',
                 # if use sessions, setup runtime service, Session, and Sampler
                 if use_sessions:
                     from qiskit_ibm_runtime import QiskitRuntimeService, Sampler, Session, Options
-                    global service
-                    global sampler
                     
                     service = QiskitRuntimeService()
                     session_count += 1
@@ -411,6 +416,68 @@ def set_execution_target(backend_id='qasm_simulator',
                     backend = provider.get_backend(backend_id)
             else:
                 print(authentication_error_msg.format("IBMQ"))
+
+        ###############################
+        # otherwise, assume the backend_id is given only and assume it is IBM Cloud device
+        else:
+            from qiskit_ibm_runtime import QiskitRuntimeService, Sampler, Session, Options
+            
+            # create the Runtime Service object
+            service = QiskitRuntimeService()
+            
+            # obtain a backend from the service
+            backend = service.backend(backend_id)
+               
+            # DEVNOTE: here we assume if the sessions flag is set, we use Sampler
+            # however, we may want to add a use_sampler option so that we can separate these
+            
+            # set use_sessions if provided by user - NOTE: this will modify the global setting
+            this_use_sessions = exec_options.get("use_sessions", None)
+            if this_use_sessions != None:
+                use_sessions = this_use_sessions
+
+            # if use sessions, setup runtime service, Session, and Sampler
+            if use_sessions:
+            
+                if verbose:
+                    print("... using sessions")
+                
+                session = Session(service=service, backend=backend_id)
+                
+                # get Sampler resilience level and transpiler optimization level from exec_options
+                options = Options()
+                options.resilience_level = exec_options.get("resilience_level", 1)
+                options.optimization_level = exec_options.get("optimization_level", 3)
+                
+                # special handling for ibmq_qasm_simulator to set noise model
+                if backend_id == "ibmq_qasm_simulator":
+                    this_noise = noise
+                    
+                    # get noise model from options; used only in simulators for now
+                    if "noise_model" in exec_options:
+                        this_noise = exec_options.get("noise_model", None)
+                        if verbose:
+                            print(f"... using custom noise model: {this_noise}")
+                            
+                    # attach to backend if not None
+                    if this_noise != None:
+                        options.simulator = {"noise_model": this_noise}
+                        metrics.QV = this_noise.QV
+                        if verbose:
+                            print(f"... setting noise model, QV={this_noise.QV} on {backend_id}")
+                    
+                if verbose:
+                    print(f"... execute using Sampler on backend_id {backend_id} with options = {options}")
+                
+                # create the Qiskit Sampler with these options
+                sampler = Sampler(session=session, options=options)
+                
+            # otherwise, use the circuit runner in the submit_circuit method, without sessions
+            else: 
+                if verbose:
+                    print("... not using sessions")
+                    print(f"... execute using Circuit Runner on backend_id {backend_id}")
+
 
     # create an informative device name for plots
     device_name = backend_id


### PR DESCRIPTION
Cannot use IBM!.load_account() for authentication. The IBMQ provider object cannot be used for circuit-runner.