### PR TITLE
Add HHL option to set min number of qubits for input and clock registers

### DIFF
--- a/hhl/qiskit/benchmarks-qiskit-hhl.ipynb
+++ b/hhl/qiskit/benchmarks-qiskit-hhl.ipynb
@@ -26,7 +26,7 @@
     "backend_id=\"qasm_simulator\"\n",
     "hub=\"ibm-q\"; group=\"open\"; project=\"main\"\n",
     "provider_backend = None\n",
-    "exec_options = None\n",
+    "exec_options = {}\n",
     "\n",
     "# # ==========================\n",
     "# # *** If using IBMQ hardware, run this once to authenticate\n",
@@ -110,6 +110,9 @@
     "\n",
     "hhl_benchmark.verbose=False\n",
     "\n",
+    "# minimum number of qubits for input and clock registers\n",
+    "hhl_benchmark.min_register_qubits=1\n",
+    "\n",
     "hhl_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                method=1, use_best_widths=True,\n",
     "                backend_id=backend_id, provider_backend=provider_backend,\n",
@@ -181,7 +184,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (ipykernel)",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/hhl/qiskit/hhl_benchmark.py
+++ b/hhl/qiskit/hhl_benchmark.py
@@ -37,6 +37,9 @@ verbose = False
 # Variable for number of resets to perform after mid circuit measurements
 num_resets = 1
 
+# Minimum qubit size for input and clock registers
+min_register_qubits = 1
+
 # saved circuits for display
 QC_ = None
 U_ = None
@@ -786,7 +789,13 @@ def run2 (min_input_qubits=1, max_input_qubits=3, skip_qubits=1,
                     if verbose:   
                         print(f"... SKIPPING {num_circuits} circuits with {num_qubits} qubits, using {num_input_qubits} input qubits and {num_clock_qubits} clock qubits")
                     continue
-                    
+            
+            # skip if input or clock size smaller than minimum
+            if min_register_qubits > 1 and num_input_qubits < min_register_qubits or num_clock_qubits < min_register_qubits:
+                if verbose:
+                    print(f"... SKIPPING {num_circuits} circuits with {num_input_qubits} input qubits and {num_clock_qubits} clock qubits")
+                continue
+                  
             print(f"************\nExecuting {num_circuits} circuits with {num_qubits} qubits, using {num_input_qubits} input qubits and {num_clock_qubits} clock qubits")
             
             # loop over randomly generated problem instances


### PR DESCRIPTION
The hhl_benchmark.min_register_qubits variable defaults to 1 but can be overridden