### PR TITLE
ruff: Apply ruff --fix maxcut/qiskit/

### DIFF
--- a/maxcut/qiskit/auxiliary_functions.py
+++ b/maxcut/qiskit/auxiliary_functions.py
@@ -277,7 +277,7 @@ def plot_from_data(gen_prop, radar_plot_data):
             ars = arranged_AR_arr.flatten()  # approximation ratios
             radii_plt = radii_arr.flatten()
             restart_dots = ax.scatter(angles, radii_plt, c=ars, s=100, cmap='YlGn',
-                                      marker='o', alpha=0.8, label=r'Converged Angles'.format(0+1), linewidths=0)
+                                      marker='o', alpha=0.8, label=r'Converged Angles'.format(), linewidths=0)
 
             # Plot the fixed angles
             if ind < rounds:

--- a/maxcut/qiskit/maxcut_benchmark.py
+++ b/maxcut/qiskit/maxcut_benchmark.py
@@ -15,8 +15,7 @@ from collections import namedtuple
 import numpy as np
 from scipy.optimize import minimize
 
-from qiskit import (Aer, ClassicalRegister,  # for computing expectation tables
-                    QuantumCircuit, QuantumRegister, execute, transpile)
+from qiskit import (Aer, QuantumCircuit, execute)
 from qiskit.circuit import ParameterVector
 
 sys.path[1:1] = [ "_common", "_common/qiskit", "maxcut/_common" ]
@@ -1138,7 +1137,7 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=2,
         
         # if the file does not exist, we are done with this number of qubits
         if nodes == None:
-            print(f"  ... problem not found.")
+            print("  ... problem not found.")
             break
         
         for restart_ind in range(1, max_circuits + 1):
@@ -1177,7 +1176,7 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=2,
                 # Always start by enabling transpile ...
                 ex.set_tranpilation_flags(do_transpile_metrics=True, do_transpile_for_execute=True)
                     
-                logger.info(f'===============  Begin method 2 loop, enabling transpile')
+                logger.info('===============  Begin method 2 loop, enabling transpile')
                 
                 def expectation(thetas_array):
                     
@@ -1217,7 +1216,7 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=2,
                     # after first execution and thereafter, no need for transpilation if parameterized
                     if parameterized:
                         ex.set_tranpilation_flags(do_transpile_metrics=False, do_transpile_for_execute=False)
-                        logger.info(f'**** First execution complete, disabling transpile')
+                        logger.info('**** First execution complete, disabling transpile')
                     #************************************************
                     
                     global saved_result


### PR DESCRIPTION
From https://docs.astral.sh/ruff/

> The Ruff formatter is an extremely fast Python code formatter designed as a drop-in replacement for [Black](https://pypi.org/project/black/), available as part of the ruff CLI via ruff format.
> 
> The Ruff formatter is available as a [production-ready Beta](https://astral.sh/blog/the-ruff-formatter) as of Ruff v0.1.2.

Ruff is orders of magnitude faster than Autoflake, Flake8, Pyflakes, Pycodestyle, Pylint. It is used by major projects such as Apache Airflow, FastAPI, Hugging Face, pandas, SciPy. As such, I think is a good addition to the repo to keep the code clean.