### PR TITLE
Add pre-commit containing ruff linter

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,12 @@
+ci:
+    autoupdate_schedule: 'monthly'
+    autofix_prs: false
+
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.1.11
+  hooks:
+    # Run the linter.
+    - id: ruff
+      types_or: [ python, pyi, jupyter ]


### PR DESCRIPTION
I don't exactly remember how to enable pre-commit in a GH repo (https://pre-commit.com/#plugins) but it should look like this: https://results.pre-commit.ci/run/github/42205414/1705017304.m3mnZTHiQ3eC9mW3YS30Iw.