### PR TITLE
Merge code changes to support the upgrade to qiskit 1.0

### DIFF
--- a/_common/qiskit/execute.py
+++ b/_common/qiskit/execute.py
@@ -962,7 +962,7 @@ def transpile_and_bind_circuit(circuit, params, backend, basis_gates=None,
         logger.info(f"Binding parameters to circuit: {[param[1] for param in params.items()]}")
         if verbose_time: print("  ... binding parameters")
         
-        trans_qc = trans_qc.bind_parameters(params)
+        trans_qc = trans_qc.assign_parameters(params)
         #print(trans_qc)
         
         # store original name in parameterized circuit, so it can be found with get_result()

--- a/_setup/qiskit/README.md
+++ b/_setup/qiskit/README.md
@@ -5,6 +5,8 @@
 This directory describes the requirements and operational conventions for using Qiskit as the programming environment for running the benchmark programs contained in the QC-App-Oriented-Benchmarks repository.
 In particular, this document explains how to set up the tools needed to run the Qiskit implementation of these benchmarks.
 
+**NOTE** This repository now requires Qiskit version 1.0 or greater.  A branch named **__master-240322-works-0.46** has been preserved for use with earlier versions of Qiskit. 
+
 ## Configure a Qiskit Environment
 If you are using Anaconda environments, create an environment named "qiskit" and then "activate" it using the following commands:
 

--- a/amplitude-estimation/qiskit/ae_benchmark.py
+++ b/amplitude-estimation/qiskit/ae_benchmark.py
@@ -99,13 +99,13 @@ def A_gen(num_state_qubits, a, psi_zero=None, psi_one=None):
     qc_A.x(num_state_qubits)
     for i in range(num_state_qubits):
         if psi_zero[i]=='1':
-            qc_A.cnot(num_state_qubits,i)
+            qc_A.cx(num_state_qubits,i)
     qc_A.x(num_state_qubits)
     
     # takes state to sqrt(1-a) |psi_0>|0> + sqrt(a) |psi_1>|1>
     for i in range(num_state_qubits):
         if psi_one[i]=='1':
-            qc_A.cnot(num_state_qubits,i)
+            qc_A.cx(num_state_qubits,i)
     
     return qc_A
 

--- a/hhl/qiskit/sparse_Ham_sim.py
+++ b/hhl/qiskit/sparse_Ham_sim.py
@@ -9,8 +9,7 @@ import numpy as np
 from scipy.linalg import expm
 
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
-from qiskit import Aer, execute
-
+from qiskit_aer import Aer
 
 def Ham_sim(H, t):
     """
@@ -193,7 +192,7 @@ def W_gate(qc, q0, q1):
 def qc_unitary(qc):
     
     simulator = Aer.get_backend('unitary_simulator')
-    result = execute(qc, simulator).result()
+    result = simulator.run(qc).result()
     U = np.array(result.get_unitary(qc))
     
     return U
@@ -201,7 +200,7 @@ def qc_unitary(qc):
 def sim_circuit(qc, shots):
     
     simulator = Aer.get_backend('qasm_simulator')
-    result = execute(qc, simulator, shots=shots).result()
+    result = simulator.run(qc, shots=shots).result()
     outcomes = result.get_counts(qc)
     
     return outcomes

--- a/hhl/qiskit/uniform_controlled_rotation.py
+++ b/hhl/qiskit/uniform_controlled_rotation.py
@@ -9,7 +9,6 @@ import numpy as np
 from sympy.combinatorics.graycode import GrayCode
 
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
-#from qiskit import Aer, execute
 from qiskit_aer import Aer
 
 

--- a/hhl/qiskit/uniform_controlled_rotation.py
+++ b/hhl/qiskit/uniform_controlled_rotation.py
@@ -9,7 +9,8 @@ import numpy as np
 from sympy.combinatorics.graycode import GrayCode
 
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
-from qiskit import Aer, execute
+#from qiskit import Aer, execute
+from qiskit_aer import Aer
 
 
 def dot_product(str1, str2):
@@ -148,7 +149,7 @@ def test_circuit(n):
 def sim_circuit(qc, shots):
     
     simulator = Aer.get_backend('qasm_simulator')
-    result = execute(qc, simulator, shots=shots).result()
+    result = simulator.run(qc, shots=shots).result()
     outcomes = result.get_counts(qc)
     
     

--- a/hydrogen-lattice/Dev/Main_opt.py
+++ b/hydrogen-lattice/Dev/Main_opt.py
@@ -43,7 +43,7 @@ lowest_energy_values = []
 def compute_energy(circuit, operator, shots, parameters): 
     
     # Bind the parameters to the circuit
-    bound_circuit = circuit.bind_parameters(parameters)
+    bound_circuit = circuit.assign_parameters(parameters)
     
     # Compute the expectation value of the circuit with respect to the Hamiltonian for optimization
     energy = ideal_backend.compute_expectation(bound_circuit, operator=operator, shots=shots)

--- a/hydrogen-lattice/qiskit/hydrogen_lattice_benchmark.py
+++ b/hydrogen-lattice/qiskit/hydrogen_lattice_benchmark.py
@@ -15,16 +15,17 @@ from typing import Optional
 import numpy as np
 from scipy.optimize import minimize
 
-from qiskit import Aer, QuantumCircuit, execute
+from qiskit import QuantumCircuit
+from qiskit_aer import Aer
+
 from qiskit.circuit import ParameterVector
 from qiskit.quantum_info import SparsePauliOp
 from qiskit.result import sampled_expectation_value
 
-
+# QED-C benchmark-specific imports
 sys.path[1:1] = ["_common", "_common/qiskit", "hydrogen-lattice/_common"]
 sys.path[1:1] = ["../../_common", "../../_common/qiskit", "../../hydrogen-lattice/_common/"]
 
-# benchmark-specific imports
 import common
 import execute as ex
 import metrics as metrics
@@ -536,11 +537,11 @@ def compute_expectation(qc, num_qubits, secret_int, backend_id="statevector_simu
     qc = qc.remove_final_measurements(inplace=False)
 
     if params is not None:
-        qc = qc.bind_parameters(params)
+        qc = qc.assign_parameters(params)
 
     # execute statevector simulation
     sv_backend = Aer.get_backend(backend_id)
-    sv_result = execute(qc, sv_backend, params=params).result()
+    sv_result = sv_backend.run(qc, params=params).result()
 
     # get the probability distribution
     counts = sv_result.get_counts()
@@ -1369,7 +1370,7 @@ def run(
                 # for testing and debugging ...
                 #if using parameter objects, bind before printing
                 if verbose:
-                    print(qc.bind_parameters(params) if parameterized else qc)
+                    print(qc.assign_parameters(params) if parameterized else qc)
                 """
                 # store the creation time for these circuits
                 metrics.store_metric(num_qubits, instance_num, "create_time", time.time() - ts)
@@ -1499,7 +1500,7 @@ def run(
                         for qc in qc_array:
                             # bind parameters to circuit before execution
                             if parameterized:
-                                qc.bind_parameters(params)
+                                qc.assign_parameters(params)
                                 
                             # submit circuit for execution on target with the current parameters
                             ex.submit_circuit(qc, num_qubits, unique_id, shots=num_shots, params=params)

--- a/image-recognition/Dev/image_recog_QCNN 4 qubit Version.py
+++ b/image-recognition/Dev/image_recog_QCNN 4 qubit Version.py
@@ -287,7 +287,7 @@ def loss_function(theta, x_batch, y_batch, is_draw_circ=False, is_print=False):
     for data_point, label in zip(x_batch, y_batch):
         # Create the quantum circuit for the data point
         qc = qcnn_model(data_point, num_qubits)
-        qc_upd = qc.bind_parameters(theta)
+        qc_upd = qc.assign_parameters(theta)
         if i_draw==0 and is_draw_circ:
             print(qc_upd)
             i_draw += 1
@@ -388,7 +388,7 @@ predictions = []
 test_accuracy_history = []
 for data_point in x_final_test:
     qc = qcnn_model(data_point, num_qubits)
-    qc_upd = qc.bind_parameters(theta.x)
+    qc_upd = qc.assign_parameters(theta.x)
         # Simulate the quantum circuit and get the result
     if expectation_calc_method == True:
         # val = expectation_calc_qcnn.calculate_expectation(qc,shots=num_shots,num_qubits=num_qubits)   

--- a/image-recognition/Dev/image_recog_QCNN Visualize.py
+++ b/image-recognition/Dev/image_recog_QCNN Visualize.py
@@ -338,7 +338,7 @@ def loss_function(theta, is_draw_circ=True, is_print=True):
         # Create the quantum circuit for the data point
         qc = qcnn_model( data_point, num_qubits)
         
-        qc_upd = qc.bind_parameters(theta)
+        qc_upd = qc.assign_parameters(theta)
         
         if i_draw==0 and is_draw_circ:
             print(qc_upd)

--- a/image-recognition/Dev/image_recog_QCNN_8qubit Version.py
+++ b/image-recognition/Dev/image_recog_QCNN_8qubit Version.py
@@ -311,7 +311,7 @@ def loss_function(theta, x_batch, y_batch, is_draw_circ=False, is_print=False):
     for data_point, label in zip(x_batch, y_batch):
         # Create the quantum circuit for the data point
         qc = qcnn_model(data_point, num_qubits)
-        qc_upd = qc.bind_parameters(theta)
+        qc_upd = qc.assign_parameters(theta)
         
         if i_draw==0 and is_draw_circ:
             print(qc_upd)
@@ -415,7 +415,7 @@ test_accuracy_history = []
 for data_point in x_final_test:
     qc = qcnn_model(data_point, num_qubits)
     
-    qc_upd = qc.bind_parameters(theta.x)
+    qc_upd = qc.assign_parameters(theta.x)
     # Simulate the quantum circuit and get the result
     
     # qc = qc.assign_parameters(theta.x)

--- a/image-recognition/README.md
+++ b/image-recognition/README.md
@@ -1,5 +1,7 @@
 # Image Recognition - Benchmark Program
 
+**NOTE:** This benchmark program will not function with Qiskit 1.0, as the opflow package has been completely removed.  However, it will execute with Qiskit <= 0.46. This is an active issue and the benchmark will be updated soon.
+
 NOTE: This entire README is a WORK-IN-PROGRESS
 
 This benchmark uses Quantum neural networks & Quantum Machine Learning  [[1]](#references) as an example of a quantum application that can classify images from mnist data set using classical optimizer

--- a/image-recognition/qiskit/image_recognition_benchmark.py
+++ b/image-recognition/qiskit/image_recognition_benchmark.py
@@ -722,7 +722,7 @@ def compute_expectation(qc, num_qubits, secret_int, backend_id="statevector_simu
     qc = qc.remove_final_measurements(inplace=False)
 
     if params is not None:
-        qc = qc.bind_parameters(params)
+        qc = qc.assign_parameters(params)
 
     # execute statevector simulation
     sv_backend = Aer.get_backend(backend_id)
@@ -1533,7 +1533,7 @@ def run(
 
                 # bind parameters to circuit before execution
                 # if parameterized:
-                #     qc.bind_parameters(params)
+                #     qc.assign_parameters(params)
             
                 # submit circuit for execution on target with the current parameters
                 ex.submit_circuit(qc, num_qubits, unique_id, shots=num_shots, params=params)
@@ -1747,7 +1747,7 @@ def run(
             # for testing and debugging ...
             #if using parameter objects, bind before printing
             if verbose:
-                print(qc.bind_parameters(params) if parameterized else qc)
+                print(qc.assign_parameters(params) if parameterized else qc)
             """
             # store the creation time for these circuits
             metrics.store_metric(num_qubits, instance_num, "create_time", time.time() - ts)

--- a/maxcut/ocean/maxcut_benchmark.py
+++ b/maxcut/ocean/maxcut_benchmark.py
@@ -115,7 +115,7 @@ def compute_expectation(qc, num_qubits, secret_int, backend_id='statevector_simu
     
     #ts = time.time()
     if params != None:
-        qc = qc.bind_parameters(params)
+        qc = qc.assign_parameters(params)
     
     #execute statevector simulation
     sv_backend = Aer.get_backend(backend_id)

--- a/maxcut/qiskit/benchmarks-qiskit-maxcut.ipynb
+++ b/maxcut/qiskit/benchmarks-qiskit-maxcut.ipynb
@@ -365,10 +365,10 @@
     "qc.measure(qr[2], cr[2])\n",
     "qc.measure(qr[3], cr[3])\n",
     "\n",
-    "from qiskit import execute, Aer\n",
+    "from qiskit_aer import Aer\n",
     "backend = Aer.get_backend(\"qasm_simulator\")  # Use Aer qasm_simulator\n",
     "\n",
-    "job = execute(qc, backend, shots=1000)\n",
+    "job = backend.run(qc, shots=1000)\n",
     "result = job.result()\n",
     "counts = result.get_counts(qc)\n",
     "print(\"Total counts are:\", counts)\n",
@@ -384,7 +384,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -398,7 +398,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.11.5"
   },
   "vscode": {
    "interpreter": {

--- a/maxcut/qiskit/maxcut_benchmark.py
+++ b/maxcut/qiskit/maxcut_benchmark.py
@@ -256,7 +256,7 @@ def compute_expectation(qc, num_qubits, secret_int, backend_id='statevector_simu
     
     #ts = time.time()
     if params != None:
-        qc = qc.bind_parameters(params)
+        qc = qc.assign_parameters(params)
     
     #execute statevector simulation
     sv_backend = Aer.get_backend(backend_id)

--- a/maxcut/qiskit/maxcut_benchmark.py
+++ b/maxcut/qiskit/maxcut_benchmark.py
@@ -15,9 +15,11 @@ from collections import namedtuple
 import numpy as np
 from scipy.optimize import minimize
 
-from qiskit import (Aer, QuantumCircuit, execute)
+from qiskit_aer import Aer
+from qiskit import QuantumCircuit
 from qiskit.circuit import ParameterVector
 
+# QED-C imports
 sys.path[1:1] = [ "_common", "_common/qiskit", "maxcut/_common" ]
 sys.path[1:1] = [ "../../_common", "../../_common/qiskit", "../../maxcut/_common/" ]
 import common
@@ -258,7 +260,7 @@ def compute_expectation(qc, num_qubits, secret_int, backend_id='statevector_simu
     
     #execute statevector simulation
     sv_backend = Aer.get_backend(backend_id)
-    sv_result = execute(qc, sv_backend).result()
+    sv_result = sv_backend.run(qc).result()
 
     # get the probability distribution
     counts = sv_result.get_counts()

--- a/maxcut/qiskit/qiskit-parameters-example.ipynb
+++ b/maxcut/qiskit/qiskit-parameters-example.ipynb
@@ -125,7 +125,7 @@
     "\n",
     "    # bind parameters to the saved and already transpiled circuit\n",
     "    if VERBOSE: print(f\"\\nBinding {thetas = } to qc_exec\")\n",
-    "    qc_exec = qc_trans.bind_parameters({params: thetas})\n",
+    "    qc_exec = qc_trans.assign_parameters({params: thetas})\n",
     "\n",
     "    # execute this transpiled and bound circuit on the backend\n",
     "    job = BACKEND.run(qc_exec, shots=NUM_SHOTS)\n",


### PR DESCRIPTION
These changes address issued identified by users when executing against Qiskit version 1.0.
Most benchmarks work, except vqe and image-recognition, which use opflow (now deprecated).