### PR TITLE
Fix unit tests, add basic random paulis for hamlib

### DIFF
--- a/hamiltonian-simulation/qiskit/hamiltonian_simulation_kernel.py
+++ b/hamiltonian-simulation/qiskit/hamiltonian_simulation_kernel.py
@@ -365,7 +365,7 @@ class TfimHamiltonianKernel(HamiltonianKernel):
 
     #apply tfim hamiltonian.
     def create_hamiltonian(self) -> QuantumCircuit:
-        self.h = 0.2
+        self.h = 1
         qr = QuantumRegister(self.n_spins)
         qc = QuantumCircuit(qr, name="TFIM")
         for k in range(self.K):

--- a/hamiltonian-simulation/qiskit/test_hamiltonian_simulation.py
+++ b/hamiltonian-simulation/qiskit/test_hamiltonian_simulation.py
@@ -1,8 +1,8 @@
 import hamiltonian_simulation_kernel as kernel
-import hamiltonian_simulation_benchmark as benchmark 
-import numpy as np 
-import os 
-import json 
+import hamiltonian_simulation_benchmark as benchmark
+import numpy as np
+import os
+import json
 import sys
 
 from qiskit.primitives import Sampler
@@ -12,65 +12,158 @@ sys.path[1:1] = ["_common", "_common/qiskit"]
 sys.path[1:1] = ["../../_common", "../../_common/qiskit", "../_common"]
 import execute as ex
 import metrics as metrics
-import hamiltonian_simulation_exact as exact 
-
+import hamiltonian_simulation_exact as exact
+from hamiltonian_simulation_kernel import (
+    HamiltonianKernel,
+    HeisenbergHamiltonianKernel,
+    TfimHamiltonianKernel,
+)
 import pytest
 
 # Import precalculated data to compare against
-filename = os.path.join(os.path.dirname(__file__), os.path.pardir, "_common", "precalculated_data.json")
-with open(filename, 'r') as file:
+filename = os.path.join(
+    os.path.dirname(__file__), os.path.pardir, "_common", "precalculated_data.json"
+)
+with open(filename, "r") as file:
     data = file.read()
 precalculated_data = json.loads(data)
 
 
-@pytest.mark.parametrize("n_spins,hamiltonian", [(spin, hamiltonian) for spin in range(2,13) for hamiltonian in ["Heisenberg","TFIM"]])
+@pytest.mark.parametrize(
+    "n_spins,hamiltonian",
+    [
+        (spin, hamiltonian)
+        for spin in range(2, 13)
+        for hamiltonian in ["Heisenberg", "TFIM"]
+    ],
+)
 def test_high_num_shots_method_1(n_spins, hamiltonian):
     """
     check high n_shots matches what's stored in precalculated_distribution by seeing if polarization fidelity is close to 1
     """
-  
+
     w = 1
-    t = .2 
+    t = 0.2
 
     np.random.seed(26)
-    hx = list(2 * np.random.random(20) - 1) # random numbers between [-1, 1]
+    hx = list(2 * np.random.random(20) - 1)  # random numbers between [-1, 1]
     np.random.seed(75)
-    hz = list(2 * np.random.random(20) - 1) # random numbers between [-1, 1]
+    hz = list(2 * np.random.random(20) - 1)  # random numbers between [-1, 1]
 
-    K = 5 
+    K = 5
 
-    ham_circ = kernel.HamiltonianSimulation(n_spins, K, t, hamiltonian, w, hx, hz, use_XX_YY_ZZ_gates= False, method=1) 
+    # Create HeisenbergKernel or TFIM kernel
+    if hamiltonian == "Heisenberg":
+        qc_object = HeisenbergHamiltonianKernel(
+            n_spins,
+            K=K,
+            t=t,
+            hamiltonian=hamiltonian,
+            w=w,
+            hx=hx,
+            hz=hz,
+            use_XX_YY_ZZ_gates=False,
+            method=1,
+            random_pauli_flag=False,
+            init_state="checkerboard",
+        )
 
+    if hamiltonian == "TFIM":
+        qc_object = TfimHamiltonianKernel(
+            n_spins,
+            K=K,
+            t=t,
+            hamiltonian=hamiltonian,
+            w=w,
+            hx=hx,
+            hz=hz,
+            use_XX_YY_ZZ_gates=False,
+            method=1,
+            random_pauli_flag=False,
+            init_state="ghz",
+        )
+
+    ham_circ = qc_object.overall_circuit()
     shots = 10000
 
-    results = Sampler().run(circuits=ham_circ, n_shots = shots).result().quasi_dists[0].binary_probabilities()
+    results = (
+        Sampler()
+        .run(circuits=ham_circ, n_shots=shots)
+        .result()
+        .quasi_dists[0]
+        .binary_probabilities()
+    )
     correct_dist = precalculated_data[f"{hamiltonian} - Qubits{n_spins}"]
 
     polar_fid = metrics.polarization_fidelity(results, correct_dist)["hf_fidelity"]
 
-    assert np.isclose(1, polar_fid, atol = .01)
+    assert np.isclose(1, polar_fid, atol=0.01)
 
-@pytest.mark.parametrize("n_spins,hamiltonian", [(spin, hamiltonian) for spin in range(2,13) for hamiltonian in ["Heisenberg","TFIM"]])
+
+@pytest.mark.parametrize(
+    "n_spins,hamiltonian",
+    [
+        (spin, hamiltonian)
+        for spin in range(2, 13)
+        for hamiltonian in ["Heisenberg", "TFIM"]
+    ],
+)
 def test_high_num_shots_method_3(n_spins, hamiltonian):
     """
-    check that, given no noise, method 3 always yields almost exactly fid = 1 
+    check that, given no noise, method 3 always yields almost exactly fid = 1
     """
 
     w = 1
-    t = .2 
+    t = 0.2
 
     np.random.seed(26)
-    hx = list(2 * np.random.random(20) - 1) # random numbers between [-1, 1]
+    hx = list(2 * np.random.random(20) - 1)  # random numbers between [-1, 1]
     np.random.seed(75)
-    hz = list(2 * np.random.random(20) - 1) # random numbers between [-1, 1]
+    hz = list(2 * np.random.random(20) - 1)  # random numbers between [-1, 1]
 
-    K = 5 
-
-    ham_circ = kernel.HamiltonianSimulation(n_spins, K, t, hamiltonian, w, hx, hz, use_XX_YY_ZZ_gates= False, method=3, random_pauli_flag = False) 
+    K = 5
 
     shots = 10000
 
-    results = Sampler().run(circuits=ham_circ, n_shots = shots).result().quasi_dists[0].binary_probabilities()
+    # Create HeisenbergKernel or TFIM kernel
+    if hamiltonian == "Heisenberg":
+        qc_object = HeisenbergHamiltonianKernel(
+            n_spins,
+            K=K,
+            t=t,
+            hamiltonian=hamiltonian,
+            w=w,
+            hx=hx,
+            hz=hz,
+            use_XX_YY_ZZ_gates=False,
+            method=3,
+            random_pauli_flag=False,
+            init_state="checkerboard",
+        )
+
+    if hamiltonian == "TFIM":
+        qc_object = TfimHamiltonianKernel(
+            n_spins,
+            K=K,
+            t=t,
+            hamiltonian=hamiltonian,
+            w=w,
+            hx=hx,
+            hz=hz,
+            use_XX_YY_ZZ_gates=False,
+            method=3,
+            random_pauli_flag=False,
+            init_state="ghz",
+        )
+
+    ham_circ = qc_object.overall_circuit()
+    results = (
+        Sampler()
+        .run(circuits=ham_circ, n_shots=shots)
+        .result()
+        .quasi_dists[0]
+        .binary_probabilities()
+    )
 
     # print(results)
 
@@ -86,65 +179,120 @@ def test_high_num_shots_method_3(n_spins, hamiltonian):
 
     assert np.isclose(1, polar_fid)
 
-@pytest.mark.parametrize("n_spins,hamiltonian", [(spin, hamiltonian) for spin in range(2,13) for hamiltonian in ["Heisenberg","TFIM"]])
+
+@pytest.mark.parametrize(
+    "n_spins,hamiltonian",
+    [
+        (spin, hamiltonian)
+        for spin in range(2, 13)
+        for hamiltonian in ["Heisenberg", "TFIM"]
+    ],
+)
 def test_high_num_shots_method_2(n_spins, hamiltonian):
     """
-    For 2-12 qubits, check that that method 2 is not completely off (i.e, close to zero) and gives some number greater than .01 
+    For 2-12 qubits, check that that method 2 is not completely off (i.e, close to zero) and gives some number greater than .01
     """
 
     w = 1
-    t = .2 
+    t = 0.2
 
     np.random.seed(26)
-    hx = list(2 * np.random.random(20) - 1) # random numbers between [-1, 1]
+    hx = list(2 * np.random.random(20) - 1)  # random numbers between [-1, 1]
     np.random.seed(75)
-    hz = list(2 * np.random.random(20) - 1) # random numbers between [-1, 1]
+    hz = list(2 * np.random.random(20) - 1)  # random numbers between [-1, 1]
 
-    K = 5 
-
-    ham_circ = kernel.HamiltonianSimulation(n_spins, K, t, hamiltonian, w, hx, hz, use_XX_YY_ZZ_gates= False, method=1, random_pauli_flag = False) 
+    K = 5
 
     shots = 10000
 
-    results = Sampler().run(circuits=ham_circ, n_shots = shots).result().quasi_dists[0].binary_probabilities()
+    # Create HeisenbergKernel or TFIM kernel
+    if hamiltonian == "Heisenberg":
+        qc_object = HeisenbergHamiltonianKernel(
+            n_spins,
+            K=K,
+            t=t,
+            hamiltonian=hamiltonian,
+            w=w,
+            hx=hx,
+            hz=hz,
+            use_XX_YY_ZZ_gates=False,
+            method=1,
+            random_pauli_flag=False,
+            init_state="checkerboard",
+        )
+
+    if hamiltonian == "TFIM":
+        qc_object = TfimHamiltonianKernel(
+            n_spins,
+            K=K,
+            t=t,
+            hamiltonian=hamiltonian,
+            w=w,
+            hx=hx,
+            hz=hz,
+            use_XX_YY_ZZ_gates=False,
+            method=1,
+            random_pauli_flag=False,
+            init_state="ghz",
+        )
+
+    ham_circ = qc_object.overall_circuit()
+    results = (
+        Sampler()
+        .run(circuits=ham_circ, n_shots=shots)
+        .result()
+        .quasi_dists[0]
+        .binary_probabilities()
+    )
 
     correct_dist = precalculated_data[f"Exact {hamiltonian} - Qubits{n_spins}"]
 
     polar_fid = metrics.polarization_fidelity(results, correct_dist)["hf_fidelity"]
 
-    assert np.greater(polar_fid, .01)
+    assert np.greater(polar_fid, 0.01)
 
-@pytest.mark.skip(reason="To be resolved: Inconsistency in the way qiskit/our code defines 2Q rotation angles?")
-@pytest.mark.parametrize("n_spins,hamiltonian", [(spin, hamiltonian) for spin in range(2, 13) for hamiltonian in ["Heisenberg", "TFIM"]])
+
+@pytest.mark.skip(
+    reason="To be resolved: Inconsistency in the way qiskit/our code defines 2Q rotation angles?"
+)
+@pytest.mark.parametrize(
+    "n_spins,hamiltonian",
+    [
+        (spin, hamiltonian)
+        for spin in range(2, 13)
+        for hamiltonian in ["Heisenberg", "TFIM"]
+    ],
+)
 def test_qiskit_matches_manual(n_spins, hamiltonian):
     """
-    Check that the circuits that qiskit forms returns the same output as ours, if the gates are placed in the same order. 
+    Check that the circuits that qiskit forms returns the same output as ours, if the gates are placed in the same order.
     """
 
     w = 1
-    t = .2 
+    t = 0.2
 
     np.random.seed(26)
-    hx = list(2 * np.random.random(20) - 1) # random numbers between [-1, 1]
+    hx = list(2 * np.random.random(20) - 1)  # random numbers between [-1, 1]
     np.random.seed(75)
-    hz = list(2 * np.random.random(20) - 1) # random numbers between [-1, 1]
+    hz = list(2 * np.random.random(20) - 1)  # random numbers between [-1, 1]
 
-    K = 1 
+    K = 1
 
-    ham_circ = kernel.HamiltonianSimulation(n_spins, K, t, hamiltonian, w, hx, hz, use_XX_YY_ZZ_gates= True, method=1) 
-  
     if hamiltonian == "Heisenberg":
         init_state = "checkerboard"
     else:
         init_state = "ghz"
 
-    hamiltonian_sparse = exact.construct_hamiltonian(n_spins, hamiltonian, w=1, hx=hx, hz=hz)
+    hamiltonian_sparse = exact.construct_hamiltonian(
+        n_spins, hamiltonian, w=1, hx=hx, hz=hz
+    )
 
     print(hamiltonian_sparse)
     #
     #
     from qiskit.circuit.library import PauliEvolutionGate
-    evo = PauliEvolutionGate(hamiltonian_sparse, time=t/K)
+
+    evo = PauliEvolutionGate(hamiltonian_sparse, time=t / K)
 
     from qiskit import QuantumCircuit
 
@@ -154,22 +302,71 @@ def test_qiskit_matches_manual(n_spins, hamiltonian):
 
     for _ in range(K):
         qiskit_circuit.append(evo, range(n_spins))
-    
+
     qiskit_circuit.measure_all()
 
     shots = 10000
 
-    results = Sampler().run(circuits=ham_circ, n_shots = shots).result().quasi_dists[0].binary_probabilities()
-    correct_dist = Sampler().run(circuits=qiskit_circuit, n_shots = shots).result().quasi_dists[0].binary_probabilities()
+    # Create HeisenbergKernel or TFIM kernel
+    if hamiltonian == "Heisenberg":
+        qc_object = HeisenbergHamiltonianKernel(
+            n_spins,
+            K=K,
+            t=t,
+            hamiltonian=hamiltonian,
+            w=w,
+            hx=hx,
+            hz=hz,
+            use_XX_YY_ZZ_gates=False,
+            method=1,
+            random_pauli_flag=False,
+            init_state="checkerboard",
+        )
+
+    if hamiltonian == "TFIM":
+        qc_object = TfimHamiltonianKernel(
+            n_spins,
+            K=K,
+            t=t,
+            hamiltonian=hamiltonian,
+            w=w,
+            hx=hx,
+            hz=hz,
+            use_XX_YY_ZZ_gates=False,
+            method=1,
+            random_pauli_flag=False,
+            init_state="ghz",
+        )
+
+    ham_circ = qc_object.overall_circuit()
+    results = (
+        Sampler()
+        .run(circuits=ham_circ, n_shots=shots)
+        .result()
+        .quasi_dists[0]
+        .binary_probabilities()
+    )
+    correct_dist = (
+        Sampler()
+        .run(circuits=qiskit_circuit, n_shots=shots)
+        .result()
+        .quasi_dists[0]
+        .binary_probabilities()
+    )
 
     from qiskit import transpile
-    if n_spins == 2 and hamiltonian=="Heisenberg":
-        transpile(ham_circ, ex.backend, basis_gates = ['rx', 'ry', 'rz', 'cx']).draw(filename="ourcircuit", output="mpl")
-        transpile(qiskit_circuit, ex.backend,basis_gates = ['rx', 'ry', 'rz', 'cx']).draw(filename="qiskitcirq", output="mpl")
- 
+
+    if n_spins == 2 and hamiltonian == "Heisenberg":
+        transpile(ham_circ, ex.backend, basis_gates=["rx", "ry", "rz", "cx"]).draw(
+            filename="ourcircuit", output="mpl"
+        )
+        transpile(
+            qiskit_circuit, ex.backend, basis_gates=["rx", "ry", "rz", "cx"]
+        ).draw(filename="qiskitcirq", output="mpl")
+
         ham_circ.draw(filename="baseourcircuit", output="mpl")
         qiskit_circuit.decompose().draw(filename="baseqiskitcirq", output="mpl")
 
     polar_fid = metrics.polarization_fidelity(results, correct_dist)["hf_fidelity"]
 
-    assert np.isclose(1, polar_fid, atol = .01)
+    assert np.isclose(1, polar_fid, atol=0.01)

--- a/hamlib/qiskit/hamlib_simulation_benchmark.py
+++ b/hamlib/qiskit/hamlib_simulation_benchmark.py
@@ -317,7 +317,7 @@ def run(min_qubits: int = 2, max_qubits: int = 8, max_circuits: int = 1,
                     hamiltonian=hamiltonian, init_state=init_state,
                     w=w, hx = hx, hz = hz, 
                     use_XX_YY_ZZ_gates = use_XX_YY_ZZ_gates,
-                    method = method)
+                    method = method, random_pauli_flag=random_pauli_flag)
                     
             metrics.store_metric(num_qubits, circuit_id, 'create_time', time.time() - ts)
 

--- a/hamlib/qiskit/hamlib_simulation_benchmark.py
+++ b/hamlib/qiskit/hamlib_simulation_benchmark.py
@@ -129,11 +129,16 @@ def analyze_and_print_result(qc, result, num_qubits: int,
         ts = time.time()
         correct_dist = HamiltonianSimulationExact(n_spins=num_qubits,init_state=init_state)
         if verbose:
-            print(f"... exact computation time = {round((time.time() - ts), 3)} sec") 
-            
-    elif method == 3:
-        correct_dist = key_from_initial_state(num_qubits, num_shots, init_state, random_pauli_flag)
-        
+            print(f"... exact computation time = {round((time.time() - ts), 3)} sec")
+
+    elif method == 3 and not random_pauli_flag:
+        correct_dist = key_from_initial_state(
+            num_qubits, num_shots, init_state, random_pauli_flag
+        )
+    elif method == 3 and random_pauli_flag:
+        # random_pauli_flag is (for now) set to always return bitstring of 1's
+        correct_dist = {"1" * num_qubits: num_shots}
+
     else:
         raise ValueError("Method is not 1 or 2 or 3, or hamiltonian is not valid.")
 

--- a/hamlib/qiskit/hamlib_simulation_kernel.py
+++ b/hamlib/qiskit/hamlib_simulation_kernel.py
@@ -184,7 +184,7 @@ def create_circuit(
     init_state=None,
     random_pauli_flag=False,
 ):
-   """
+    """
     Create a quantum circuit based on the Hamiltonian data from an HDF5 file.
 
     Steps:
@@ -252,7 +252,6 @@ def create_circuit(
             INV_ = inv = evo.inverse()
             inv.name = "e^iHt"
             circuit = create_trotter_steps(num_trotter_steps, inv, operator, circuit)
-            circuit.append(circuit_inverse, range(operator.num_qubits))
 
         elif method == 3 and random_pauli_flag:
             circuit, _ = convert_to_mirror_circuit(circuit_without_initial_state)
@@ -260,7 +259,8 @@ def create_circuit(
         # convert_to_mirror_circuit adds its own measurement gates
         if not random_pauli_flag:
             circuit.measure_all()
-       return circuit, hamiltonian, evo
+
+        return circuit, hamiltonian, evo
     else:
         # print(f"Dataset not available for n_spins = {n_spins}.")
         return None, None, None
@@ -299,7 +299,7 @@ def initial_state(n_spins: int, initial_state: str = "checker") -> QuantumCircui
 def HamiltonianSimulation(n_spins: int, K: int, t: float,
             hamiltonian: str, w: float, hx: list[float], hz: list[float],
             use_XX_YY_ZZ_gates: bool = False, init_state=None,
-            method: int = 1) -> QuantumCircuit:
+            method: int = 1, random_pauli_flag = False) -> QuantumCircuit:
     """
     Construct a Qiskit circuit for Hamiltonian simulation.
 

--- a/hamlib/qiskit/pygsti_mirror.py
+++ b/hamlib/qiskit/pygsti_mirror.py
@@ -1,0 +1,347 @@
+import pygsti
+import tqdm
+import numpy as np
+import scipy as sp
+from qiskit import transpile, QuantumCircuit
+
+# Below code created by Timothy Proctor, July 16 2024, using code developed by various members of Sandia's QPL.
+
+def sample_mirror_circuits(c, num_mcs=100, randomized_state_preparation=True, rand_state=None):
+    if rand_state is None:
+        rand_state = np.random.RandomState()
+        
+    mirror_circuits = []
+    mirror_circuits_bitstrings = []
+    for j in range(num_mcs):
+        mc, bs = central_pauli_mirror_circuit(c, randomized_state_preparation=randomized_state_preparation,
+                                              rand_state=rand_state)
+        mirror_circuits.append(mc)
+        mirror_circuits_bitstrings.append(bs)
+
+    return mirror_circuits, mirror_circuits_bitstrings
+
+def sample_reference_circuits(qubits, num_ref=100, randomized_state_preparation=True, rand_state=None):
+    if rand_state is None:
+        rand_state = np.random.RandomState()
+              
+    ref_circuits = []
+    ref_circuits_bitstrings = []
+    for j in range(num_ref):
+        empty_circuit = pygsti.circuits.Circuit('', line_labels=qubits)
+        ref_c, bs = central_pauli_mirror_circuit(empty_circuit, 
+                                                 randomized_state_preparation=randomized_state_preparation,
+                                                 rand_state=rand_state)
+        ref_circuits.append(ref_c)
+        ref_circuits_bitstrings.append(bs)
+
+    return ref_circuits, ref_circuits_bitstrings
+
+def central_pauli_mirror_circuit(circ, randomized_state_preparation=True, rand_state=None):
+    if rand_state is None:
+        rand_state = np.random.RandomState()
+
+    qubits = circ.line_labels
+    if randomized_state_preparation:
+        prep_circ = pygsti.circuits.Circuit([haar_random_u3_layer(qubits, rand_state)], line_labels=qubits)
+        circuit_to_mirror = prep_circ + circ
+    else: 
+        circuit_to_mirror = circ
+
+    n = circuit_to_mirror.width
+    d = circuit_to_mirror.depth
+
+    # SONNY'S EDIT TO TIM CODE: MAKE THE CENTRAL PAULI (for now) NOT RANDOM
+    # Note that we could rework the code to pass in a desired bitstring here later, rather than randomly generating one here.
+    #central_pauli = 2 * rand_state.randint(0, 2, 2*n)
+    central_pauli = 2 * np.ones(2*n, dtype = np.int8 )  
+    central_pauli_layer = pauli_vector_to_u3_layer(central_pauli, qubits)
+    q = central_pauli.copy()
+
+    quasi_inverse_circ = pygsti.circuits.Circuit(line_labels=circ.line_labels, editable=True)
+
+    for i in range(d):
+        
+        layer = circuit_to_mirror.layer_label(d - i - 1).components
+        quasi_inverse_layer = [gate_inverse(gate_label) for gate_label in layer]
+        
+        # Update the u3 gates.
+        if len(layer) == 0 or layer[0].name == 'Gu3':
+            # update_u3_parameters now twirls/adds label for empty qubits, so don't prepad for speed
+            #padded_layer = pad_layer(quasi_inverse_layer, qubits)
+            #quasi_inverse_layer = update_u3_parameters(padded_layer, q, q, qubits)
+            quasi_inverse_layer = update_u3_parameters(quasi_inverse_layer, q, q, qubits)
+            
+        # Update q based on the CNOTs in the layer.
+        else:
+            for g in layer:
+                if g.name == 'Gcnot':
+                    (control, target) = g.qubits
+                    q[qubits.index(control)] = (q[qubits.index(control)] + q[qubits.index(target)]) % 4
+                    q[n + qubits.index(target)] = (q[n + qubits.index(control)] + q[n + qubits.index(target)]) % 4
+                else:
+                    raise ValueError("Circuit can only contain Gcnot and Gu3 gates in separate layers!")
+
+        quasi_inverse_circ.insert_layer_inplace(quasi_inverse_layer, i)
+
+    mc = circuit_to_mirror + pygsti.circuits.Circuit([central_pauli_layer], line_labels=circ.line_labels) + quasi_inverse_circ
+    mc.done_editing()
+
+    bs = ''.join([str(b // 2) for b in q[n:]])
+
+    return mc, bs
+
+def pauli_vector_to_u3_layer(p, qubits):
+    
+    n = len(qubits)
+    layer = []
+    for i, q in enumerate(qubits):
+
+        if p[i] == 0 and p[i+n] == 0:  # I
+            theta = 0.0
+            phi = 0.0
+            lamb = 0.0
+        if p[i] == 2 and p[i+n] == 0:  # Z
+            theta = 0.0
+            phi = np.pi / 2
+            lamb = np.pi / 2
+        if p[i] == 0 and p[i+n] == 2:  # X
+            theta = np.pi
+            phi = 0.0
+            lamb = np.pi
+        if p[i] == 2 and p[i+n] == 2:  # Y
+            theta = np.pi
+            phi = np.pi / 2
+            lamb = np.pi / 2
+
+        layer.append(pygsti.baseobjs.Label('Gu3', q, args=(theta, phi, lamb)))
+
+    return pygsti.baseobjs.Label(layer)
+
+def haar_random_u3_layer(qubits, rand_state=None):
+    
+    return pygsti.baseobjs.Label([haar_random_u3(q, rand_state) for q in qubits])
+
+def haar_random_u3(q, rand_state=None):
+    if rand_state is None:
+        rand_state = np.random.RandomState()
+
+    a, b = 2 * np.pi * rand_state.rand(2)
+    theta = mod_2pi(2 * np.arcsin(np.sqrt(rand_state.rand(1)))[0])
+    phi = mod_2pi(a - b + np.pi)
+    lamb = mod_2pi(-1 * (a + b + np.pi))
+    return pygsti.baseobjs.Label('Gu3', q, args=(theta, phi, lamb))
+
+def mod_2pi(theta):
+    while (theta > np.pi or theta <= -1 * np.pi):
+        if theta > np.pi:
+            theta = theta - 2 * np.pi
+        elif theta <= -1 * np.pi:
+            theta = theta + 2 * np.pi
+    return theta
+
+def inverse_u3(args):
+    theta_inv = mod_2pi(-float(args[0]))
+    phi_inv = mod_2pi(-float(args[2]))
+    lambda_inv = mod_2pi(-float(args[1]))
+    return (theta_inv, phi_inv, lambda_inv)
+
+def gate_inverse(label):
+    if label.name == 'Gcnot':
+        return label
+    elif label.name == 'Gu3':
+        return pygsti.baseobjs.label.LabelTupWithArgs.init('Gu3', label.qubits, args=inverse_u3(label.args))
+
+def pad_layer(layer, qubits):
+
+    padded_layer = list(layer)
+    used_qubits = []
+    for g in layer:
+        for q in g.qubits:
+            used_qubits.append(q)
+
+    for q in qubits:
+        if q not in used_qubits:
+            padded_layer.append(pygsti.baseobjs.label.LabelTupWithArgs.init('Gu3', (q,), args=(0.0, 0.0, 0.0)))
+
+    return padded_layer
+
+
+def update_u3_parameters(layer, p, q, qubits):
+    """
+    Takes a layer containing u3 gates, and finds a new layer containing
+    u3 gates that implements p * layer * q (p followed by layer followed by
+    q), where p and q are vectors  describing layers of paulis.
+
+    """
+    used_qubits = []
+
+    new_layer = []
+    n = len(qubits)
+
+    for g in layer:
+        assert(g.name == 'Gu3')
+        (theta, phi, lamb) = (float(g.args[0]), float(g.args[1]), float(g.args[2]))
+        qubit_index = qubits.index(g.qubits[0])
+        if p[qubit_index] == 2:   # Z gate preceeding the layer
+            lamb = lamb + np.pi
+        if q[qubit_index] == 2:   # Z gate following the layer
+            phi = phi + np.pi
+        if p[n + qubit_index] == 2:  # X gate preceeding the layer
+            theta = theta - np.pi
+            phi = phi
+            lamb = -lamb - np.pi
+        if q[n + qubit_index] == 2:  # X gate following the layer
+            theta = theta - np.pi
+            phi = -phi - np.pi
+            lamb = lamb
+
+        new_args = (mod_2pi(theta), mod_2pi(phi), mod_2pi(lamb))
+        new_label = pygsti.baseobjs.label.LabelTupWithArgs.init('Gu3', g.qubits[0], args=new_args)
+        new_layer.append(new_label)
+        used_qubits.append(g.qubits[0])
+    
+#     for qubit_index, qubit in enumerate(qubits):
+#         if qubit in used_qubits:
+#             continue
+
+#         # Insert twirled idle on unpadded qubit
+#         (theta, phi, lamb) = (0.0, 0.0, 0.0)
+#         if p[qubit_index] == 2:   # Z gate preceeding the layer
+#             lamb = lamb + np.pi
+#         if q[qubit_index] == 2:   # Z gate following the layer
+#             phi = phi + np.pi
+#         if p[n + qubit_index] == 2:  # X gate preceeding the layer
+#             theta = theta - np.pi
+#             phi = phi
+#             lamb = -lamb - np.pi
+#         if q[n + qubit_index] == 2:  # X gate following the layer
+#             theta = theta - np.pi
+#             phi = -phi - np.pi
+#             lamb = lamb
+        
+#         new_args = (mod_2pi(theta), mod_2pi(phi), mod_2pi(lamb))
+#         new_label = pygsti.baseobjs.label.LabelTupWithArgs.init('Gu3', qubit, args=new_args)
+#         new_layer.append(new_label)
+#         used_qubits.append(qubit)
+#
+#    assert(set(used_qubits) == set(qubits))
+
+    return new_layer
+
+def hamming_distance_counts(data_dict, circ, idealout):
+    nQ = len(circ.line_labels)  # number of qubits
+    assert(nQ == len(idealout))
+    total = np.sum(list(data_dict.values()))
+    hamming_distance_counts = np.zeros(nQ + 1, float)
+    for outcome, counts in data_dict.items():
+        hamming_distance_counts[pygsti.tools.rbtools.hamming_distance(outcome, idealout)] += counts
+    return hamming_distance_counts
+
+def adjusted_success_probability(hamming_distance_counts):
+    if np.sum(hamming_distance_counts) == 0.: 
+        return 0.
+    else:
+        hamming_distance_pdf = np.array(hamming_distance_counts) / np.sum(hamming_distance_counts)
+        adjSP = np.sum([(-1 / 2)**n * hamming_distance_pdf[n] for n in range(len(hamming_distance_pdf))])
+        return adjSP
+
+def effective_polarization(hamming_distance_counts):
+    n = len(hamming_distance_counts) - 1 
+    asp = adjusted_success_probability(hamming_distance_counts)
+    
+    return (4**n * asp - 1)/(4**n - 1)
+
+def polarization_to_fidelity(p, n): 
+    return 1 - (4**n - 1)*(1 - p)/4**n
+
+def fidelity_to_polarization(f, n):
+    return 1 - (4**n)*(1 - f)/(4**n - 1)
+
+def predicted_process_fidelity(mirror_circuit_effective_pols, reference_effective_pols, n):
+    a = np.mean(mirror_circuit_effective_pols)
+    c = np.mean(reference_effective_pols)
+    if c <= 0.:
+        return np.nan  # raise ValueError("Reference effective polarization zero or smaller! Cannot estimate the process fidelity")
+    elif a <= 0:
+        return 0.
+    else:
+        return polarization_to_fidelity(np.sqrt(a / c), n)
+    
+def predicted_process_fidelity_with_spam_error(mirror_circuit_effective_pols, reference_effective_pols, n):
+    a = np.mean(mirror_circuit_effective_pols)
+    c = np.mean(reference_effective_pols)
+    if c <= 0.:
+        return np.nan  # raise ValueError("Reference effective polarization zero or smaller! Cannot estimate the process fidelity")
+    elif a <= 0:
+        return 0.
+    else:
+        return polarization_to_fidelity(np.sqrt(c * a), n)
+
+# Below code created by Sonny Rappaport based off of the above code provided by Tim Proctor. 
+
+def pygsti_string(qc):
+    """
+    Takes a qiskit circuit (that has been transpiled to the u3 and cx basis), and returns a pygsti-readable string. 
+    """
+
+    pygstr = ""
+
+    for gate in qc.data:
+
+        gate_str = "[" 
+
+        gate_name = gate[0].name
+        gate_qubits = [] 
+
+        for qubit in gate[1]:
+
+            # qubits look something like Qubit(QuantumRegister(4,'q1'),1)
+            gate_qubits.append(qubit._index)
+        
+        gate_parameters = gate[0].params
+
+        if gate_name == "cx":
+            gate_str = gate_str + "Gcnot"
+        elif gate_name == "u3":
+            gate_str = gate_str + "Gu3"
+        else:
+            # print(f"Passed {gate_name}")
+
+            continue
+
+        for parameter in gate_parameters:
+
+            gate_str = gate_str + f";{parameter}" 
+
+        for qubit in gate_qubits:
+
+            gate_str = gate_str + f":Q{qubit}"
+
+        gate_str = gate_str + "]"
+
+        pygstr = pygstr + gate_str
+
+    pygstr = pygstr + "@(" + f"{''.join(f'Q{i},' for i in range(qc.num_qubits))[:-1]}" + ")"
+
+    return pygstr.strip()
+
+def convert_to_mirror_circuit(qc):
+    """
+    Takes an arbitrary quantum circuit, transpiles it to CX and u3, and eventually returns a mirror circuit version of the quantum circuit. 
+
+    The mirror circuit will have a random initial state in addition to random paulis. 
+    """
+
+    qc = transpile(qc, basis_gates=["cx","u3"])
+
+    pygstr = pygsti_string(qc)
+
+    pygsti_circuit = pygsti.circuits.Circuit(pygstr)
+
+    mcs, bss = sample_mirror_circuits(pygsti_circuit, num_mcs=1)
+    print(bss)
+
+    qiskit_circuit = QuantumCircuit.from_qasm_str(mcs[0].convert_to_openqasm())
+    
+    # this circuit is made out of u3 and cx gates by pygsti default
+    return qiskit_circuit , bss[0]


### PR DESCRIPTION
- Unit tests broke when object-oriented changes to hamsim were made, this PR fixes the hamsim unit tests. 
- PR also adds basic random paulis to hamlib. To use, set method = 3 and the random pauli flag. Correct bitstring in this version will always just consist of 1 for now. 