### PR TITLE
Braket: able to get volumetric positioning plots

### DIFF
--- a/phase-estimation/braket/pe_benchmark.py
+++ b/phase-estimation/braket/pe_benchmark.py
@@ -89,13 +89,20 @@ def analyze_and_print_result (qc, result, num_counting_qubits, theta):
             counts_str[measurement] += counts_r[measurement_r]
         else:
             counts_str[measurement] = counts_r[measurement_r]
-
+    
     # get results as times a particular theta was measured
     counts = bitstring_to_theta(counts_str, num_counting_qubits)
+
+    # Convert keys of counts to strings
+    counts = {str(key): value for key, value in counts.items()}
+    
     if verbose: print(f"For theta value {theta}, measured thetas: {counts}")
 
     # correct distribution is measuring theta 100% of the time
     correct_dist = {theta: 1.0}
+
+    # convert the keys of the correct_dist dictionary into strings
+    correct_dist = {str(key): value for key, value in correct_dist.items()}  
 
     # generate thermal_dist with amplitudes instead, to be comparable to correct_dist
     bit_thermal_dist = metrics.uniform_dist(num_counting_qubits)


### PR DESCRIPTION
In Braket's execute.py, functions were added to obtain circuit metrics such as qc_depth, qc_size, and qc_count_ops. The same values were used for the transpiled metrics as those calculated for the circuit metrics.
Screenshots from the benchmarks are attached for reference.
![Quantum-Fourier-Transform-(1)-vplot](https://github.com/user-attachments/assets/dad2ddfa-8c35-4e36-b290-07fa93e0edc0)
![Quantum-Fourier-Transform-(1)-metrics](https://github.com/user-attachments/assets/cb072579-7abf-420f-9382-e1ae4f6c5164)
![Phase-Estimation-vplot](https://github.com/user-attachments/assets/414745e1-03cf-4735-af48-67e468f3f974)
![Phase-Estimation-metrics](https://github.com/user-attachments/assets/5537a679-4e7f-45ba-891d-824ed3f0b54f)
![Hidden-Shift-vplot](https://github.com/user-attachments/assets/defda9e4-0aec-4a35-aab3-8098d5f535e6)
![Hidden-Shift-metrics](https://github.com/user-attachments/assets/53643a50-0904-4f63-9201-acad78823570)
![Hamiltonian-Simulation-vplot](https://github.com/user-attachments/assets/fdfc3301-514b-4638-9a4b-7fa980ab9823)
![Hamiltonian-Simulation-metrics](https://github.com/user-attachments/assets/ef531ec4-7a9c-49fa-b5e1-d882b2137d55)
![Deutsch-Jozsa-vplot](https://github.com/user-attachments/assets/4aa9710d-cd14-4361-aeb3-b717f2782e69)
![Grover's-Search-vplot](https://github.com/user-attachments/assets/bdbd1ce2-57a7-4337-a8c6-7009f63e1cb0)
![Grover's-Search-metrics](https://github.com/user-attachments/assets/ccc94b4e-337e-4448-a30a-3e3649614494)
![Deutsch-Jozsa-metrics](https://github.com/user-attachments/assets/eb233ba5-cdc9-44b2-abd0-20481b5f45b8)
![Bernstein-Vazirani-vplot](https://github.com/user-attachments/assets/ba81dde6-7488-4e82-ba63-b7a9b0666a84)
![Bernstein-Vazirani-metrics](https://github.com/user-attachments/assets/641da5b5-2996-4f68-b372-66d2f1e10e22)
