### PR TITLE
bv_benchmark.py: make the append of mid_circuit_qubit_group out of the loop

### DIFF
--- a/bernstein-vazirani/qiskit/bv_benchmark.py
+++ b/bernstein-vazirani/qiskit/bv_benchmark.py
@@ -142,7 +142,11 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
             # create selection larger than needed and remove duplicates
             s_range = np.random.randint(1, 2**(input_size), num_circuits + 2)
             s_range = list(set(s_range))[0:max_circuits]
-            
+
+        # If mid circuit, then add 2 to new qubit group since the circuit only uses 2 qubits
+        if method == 2:
+            mid_circuit_qubit_group.append(2)
+                
         # loop over limited # of secret strings for this
         for s_int in s_range:
             s_int = int(s_int)
@@ -155,10 +159,6 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
             # convert the secret int string to array of integers, each representing one bit
             bitset = str_to_ivec(input_size, s_int)
             if verbose: print(f"... s_int={s_int} bitset={bitset}")
-                
-            # If mid circuit, then add 2 to new qubit group since the circuit only uses 2 qubits
-            if method == 2:
-                mid_circuit_qubit_group.append(2)
             
             # create the circuit for given qubit size and secret string, store time metric
             ts = time.time()


### PR DESCRIPTION
Earlier in bernstein-vazirani method-2, the qubits appended using mid_circuit_qubit_group.append(2) was appending 17 times due to present inside the loop. After the changes done, it will append only required number of qubits.

***Screenshots from the json file are attached for reference.

![Before changes](https://github.com/user-attachments/assets/aba7f191-efb8-429e-b0f3-f2de21e1a8cc)
![after changes done](https://github.com/user-attachments/assets/6637f57f-3a8b-4401-a068-6f1b60c3fe44)
