### PR TITLE
Fix incorrect file path for Max3Sat dataset in hamlib_utils.py

### DIFF
--- a/hamlib/qiskit/hamlib_utils.py
+++ b/hamlib/qiskit/hamlib_utils.py
@@ -33,7 +33,7 @@ hamiltonians = [
     HamLibData('Fermi-Hubbard-1D', 'FH_D-1.hdf5', f'{_base_url}condensedmatter/fermihubbard/FH_D-1.zip'),
     HamLibData('Bose-Hubbard-1D', 'BH_D-1_d-4.hdf5', f'{_base_url}condensedmatter/bosehubbard/BH_D-1_d-4.zip'),
     HamLibData('Heisenberg', 'heis.hdf5', f'{_base_url}condensedmatter/heisenberg/heis.zip'),
-    HamLibData('Max3Sat', 'random_max3sat-hams.hdf5', f'{_base_url}binaryoptimization/max3sat/random/random_max3sat-hams.hdf5.zip')
+    HamLibData('Max3Sat', 'random_max3sat-hams.hdf5', f'{_base_url}binaryoptimization/max3sat/random/random_max3sat-hams.zip')
 ]
 
 def create_full_filenames(hamiltonian_name):


### PR DESCRIPTION
This pull request corrects the file path for the Max3Sat dataset in the hamlib_utils.py file. The original path:
f'{_base_url}binaryoptimization/max3sat/random/random_max3sat-hams.hdf5.zip'

has been updated to:
f'{_base_url}binaryoptimization/max3sat/random/random_max3sat-hams.zip'

to avoid file download errors due to the incorrect .hdf5.zip extension.

![Screenshot from 2025-01-03 16-41-39](https://github.com/user-attachments/assets/49a08394-361a-4147-8a3a-0de38355c42a)

