### PR TITLE
Get rid of Cirq, Openfermion, and Qiskit in grouping method

### DIFF
--- a/hamlib/benchmark_hamlib_observables_custom-group.ipynb
+++ b/hamlib/benchmark_hamlib_observables_custom-group.ipynb
@@ -1,0 +1,630 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### QED-C Application-Oriented Benchmarks - Hamiltonian Simulation with HamLib - Observables (Customizable)\n",
+    "\n",
+    "The notebook contains specific examples for the HamLib-based Hamiltonian Simulation benchmark program.\n",
+    "Configure and run the cell below with the desired execution settings.\n",
+    "Then configure and run the remaining cell(s), each one a variation of this benchmark.\n",
+    "\n",
+    "Note: This set of benchmarks surfaces the series of second-level functions used to benchmark HamLib observables.\n",
+    "This is a WORK-IN-PROGRESS and is provided to enable experimentation with alternative techniques for computing observables.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%reload_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "WARNING: Qiskit-dependent compute observable value functions are not available\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "from math import sin, cos, pi\n",
+    "import time\n",
+    "\n",
+    "# Configure module paths\n",
+    "import sys\n",
+    "sys.path.insert(1, \"_common\")\n",
+    "sys.path.insert(1, \"qiskit\")\n",
+    "\n",
+    "# Import HamLib helper functions (from _common)\n",
+    "import hamlib_utils\n",
+    "\n",
+    "# Import Hamlib Simulation kernel (from qiskit)\n",
+    "import hamlib_simulation_kernel\n",
+    "\n",
+    "# Import Observable helper functions\n",
+    "import observables\n",
+    "import evolution_exact\n",
+    "\n",
+    "verbose = True\n",
+    "\n",
+    "#### for executing circuits to compute observables ...\n",
+    "\n",
+    "# Import Qiskit and Qiskit Pauli operator classes\n",
+    "#from qiskit.quantum_info import Pauli, SparsePauliOp\n",
+    "#from qiskit import QuantumCircuit\n",
+    "\n",
+    "# Initialize simulator backend\n",
+    "#from qiskit_aer import Aer\n",
+    "#backend = Aer.get_backend('qasm_simulator')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Configure Options for Execution"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Qubit width of the Hamiltonian\n",
+    "num_qubits = 6\n",
+    "\n",
+    "# Number of shots used for execution\n",
+    "num_shots = 10000\n",
+    "\n",
+    "# Parameters of Trotterized simulation\n",
+    "K = 1\n",
+    "t = 0.05\n",
+    "\n",
+    "# Define initial state; \"checkerboard\", \"neele\", \"ghz\", or a string consisting of 0s and 1s\n",
+    "init_state = \"checkerboard\"\n",
+    "\n",
+    "# for debugging Hamlib helper functions\n",
+    "hamlib_simulation_kernel.verbose = False\n",
+    "hamlib_utils.verbose = False\n",
+    "\n",
+    "# for debugging observables module\n",
+    "observables.verbose_circuits = False\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Specify a Hamiltonian for Testing\n",
+    "Choose a Hamiltonian from HamLib or create a custom Hamiltonian\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "... Hamiltonian name = TFIM\n",
+      "... dataset_name = graph-1D-grid-pbc-qubitnodes_Lx-6_h-2\n",
+      "... sparse_pauli_terms = \n",
+      "[({0: 'Z', 1: 'Z'}, (1+0j)), ({0: 'Z', 5: 'Z'}, (1+0j)), ({1: 'Z', 2: 'Z'}, (1+0j)), ({5: 'Z', 4: 'Z'}, (1+0j)), ({2: 'Z', 3: 'Z'}, (1+0j)), ({3: 'Z', 4: 'Z'}, (1+0j)), ({0: 'X'}, (2+0j)), ({1: 'X'}, (2+0j)), ({5: 'X'}, (2+0j)), ({2: 'X'}, (2+0j)), ({3: 'X'}, (2+0j)), ({4: 'X'}, (2+0j))]\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Specify the desired Hamiltonian from HamLib \n",
+    "# Set the hamiltonian_name: 'TFIM', 'Fermi-Hubbard-1D', 'Bose-Hubbard-1D', 'Heisenberg' or 'Max3Sat'\n",
+    "\n",
+    "hamiltonian_name = 'TFIM'\n",
+    "\n",
+    "print(f\"... Hamiltonian name = {hamiltonian_name}\")\n",
+    "\n",
+    "########### HamLib Hamiltonians\n",
+    "\n",
+    "if hamiltonian_name == 'TFIM':\n",
+    "    hamiltonian_params = { \"1D-grid\": \"pbc\", \"h\": 2 }\n",
+    "\n",
+    "if hamiltonian_name == 'Heisenberg':\n",
+    "    hamiltonian_params = { \"1D-grid\": \"pbc\", \"h\": 2 }\n",
+    "    \n",
+    "if hamiltonian_name == 'Fermi-Hubbard-1D':\n",
+    "    hamiltonian_params = { \"1D-grid\": \"pbc\", \"enc\": \"bk\", \"U\":12 }\n",
+    "\n",
+    "if hamiltonian_name == 'Bose-Hubbard-1D':\n",
+    "    hamiltonian_params = { \"1D-grid\": \"nonpbc\", \"enc\": \"gray\", \"U\":10 }\n",
+    "\n",
+    "if hamiltonian_name == 'Max3Sat':\n",
+    "    hamiltonian_params = { \"ratio\": \"2\", \"rinst\": \"02\" }\n",
+    "\n",
+    "if hamiltonian_name == 'chemistry/electronic/standard/H2':\n",
+    "    hamiltonian_params = { \"ham_BK\": '' }\n",
+    "\n",
+    "# load the HamLib file for the given hamiltonian name\n",
+    "hamlib_utils.load_hamlib_file(filename=hamiltonian_name)\n",
+    "\n",
+    "# return a sparse Pauli list of terms queried from the open HamLib file\n",
+    "sparse_pauli_terms, dataset_name = hamlib_utils.get_hamlib_sparsepaulilist(num_qubits=num_qubits, params=hamiltonian_params)\n",
+    "print(f\"... dataset_name = {dataset_name}\")\n",
+    "print(f\"... sparse_pauli_terms = \\n{sparse_pauli_terms}\")\n",
+    "\n",
+    "print(\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Group the Pauli Terms and Generate Merged Terms\n",
+    "Here, we optimize the grouping of the Pauli terms, both for creating the base circuit with evolution terms and for generating the measurement circuits."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "['XIIIII', 'IXIIII', 'IIIIIX', 'IIXIII', 'IIIXII', 'IIIIXI']\n",
+      "['ZZIIII', 'ZIIIIZ', 'IZZIII', 'IIIIZZ', 'IIZZII', 'IIIZZI']\n"
+     ]
+    }
+   ],
+   "source": [
+    "# DEVNOTE: expand later to include new types of optimizations\n",
+    "\n",
+    "from generate_pauli_groups import compute_groups\n",
+    "# Flag to control optimize by use of commuting groups\n",
+    "# use_commuting_groups = True\n",
+    "\n",
+    "# # group Pauli terms for quantum execution, optionally combining commuting terms into groups.\n",
+    "# pauli_term_groups, pauli_str_list = observables.group_pauli_terms_for_execution(\n",
+    "#         num_qubits, sparse_pauli_terms, use_commuting_groups)\n",
+    "\n",
+    "# print(f\"... Pauli Term Groups:\")\n",
+    "# for group in pauli_term_groups:\n",
+    "#     print(group)\n",
+    "\n",
+    "# print(f\"\\n... Merged Pauli strings, one per group:\\n  {pauli_str_list}\\n\")\n",
+    "\n",
+    "commuting_groups = compute_groups(num_qubits, sparse_pauli_terms, num_qubits)\n",
+    "for group in commuting_groups:\n",
+    "    print(group)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create a Hamiltonian Simulation Circuit\n",
+    "Initialize the circuit to a known initial state, append 'K' Trotter steps for total time 't', followed by basis rotation gates.\n",
+    "\n",
+    "Optionally, create the base circuit using grouped terms (TBD)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "... Trotterized Circuit, K=1, t=0.05\n",
+      "Sample Circuit:\n",
+      "  H = [({0: 'Z', 1: 'Z'}, (1+0j)), ({0: 'Z', 5: 'Z'}, (1+0j)), ({1: 'Z', 2: 'Z'}, (1+0j)), ({5: 'Z', 4: 'Z'}, (1+0j)), ({2: 'Z', 3: 'Z'}, (1+0j)), ({3: 'Z', 4: 'Z'}, (1+0j)), ({0: 'X'}, (2+0j)), ({1: 'X'}, (2+0j)), ({5: 'X'}, (2+0j)), ({2: 'X'}, (2+0j)), ({3: 'X'}, (2+0j)), ({4: 'X'}, (2+0j))]\n",
+      "     ┌────────┐ ░ ┌───────────────┐ ░ \n",
+      "q_0: ┤0       ├─░─┤0              ├─░─\n",
+      "     │        │ ░ │               │ ░ \n",
+      "q_1: ┤1       ├─░─┤1              ├─░─\n",
+      "     │        │ ░ │               │ ░ \n",
+      "q_2: ┤2       ├─░─┤2              ├─░─\n",
+      "     │  Neele │ ░ │  e^-iHt(0.05) │ ░ \n",
+      "q_3: ┤3       ├─░─┤3              ├─░─\n",
+      "     │        │ ░ │               │ ░ \n",
+      "q_4: ┤4       ├─░─┤4              ├─░─\n",
+      "     │        │ ░ │               │ ░ \n",
+      "q_5: ┤5       ├─░─┤5              ├─░─\n",
+      "     └────────┘ ░ └───────────────┘ ░ \n",
+      "  Initial State Neele:\n",
+      "     ┌───┐\n",
+      "q_0: ┤ X ├\n",
+      "     └───┘\n",
+      "q_1: ─────\n",
+      "     ┌───┐\n",
+      "q_2: ┤ X ├\n",
+      "     └───┘\n",
+      "q_3: ─────\n",
+      "     ┌───┐\n",
+      "q_4: ┤ X ├\n",
+      "     └───┘\n",
+      "q_5: ─────\n",
+      "          \n",
+      "  Evolution Operator (e^-iHt) =\n",
+      "                                    ┌─────────┐                      \n",
+      "q_0: ───────────■──────────■────────┤ Rx(0.2) ├──────────────────────\n",
+      "                │          │ZZ(0.1) └─────────┘           ┌─────────┐\n",
+      "q_1: ───────────┼──────────■─────────────────────■────────┤ Rx(0.2) ├\n",
+      "                │                                │ZZ(0.1) ├─────────┤\n",
+      "q_2: ───────────┼─────────────────────■──────────■────────┤ Rx(0.2) ├\n",
+      "                │                     │ZZ(0.1) ┌─────────┐└─────────┘\n",
+      "q_3: ───────────┼──────────■──────────■────────┤ Rx(0.2) ├───────────\n",
+      "                │          │ZZ(0.1) ┌─────────┐└─────────┘           \n",
+      "q_4: ─■─────────┼──────────■────────┤ Rx(0.2) ├──────────────────────\n",
+      "      │ZZ(0.1)  │ZZ(0.1) ┌─────────┐└─────────┘                      \n",
+      "q_5: ─■─────────■────────┤ Rx(0.2) ├─────────────────────────────────\n",
+      "                         └─────────┘                                 \n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# create Trotterized evolution circuit for HamLib Hamiltonian\n",
+    "\n",
+    "qc, _ = hamlib_simulation_kernel.HamiltonianSimulation(\n",
+    "    num_qubits=num_qubits, \n",
+    "    ham_op=sparse_pauli_terms,\n",
+    "    K=K, t=t,\n",
+    "    init_state = init_state,\n",
+    "    append_measurements = False,\n",
+    "    method = 1, \n",
+    ")\n",
+    "\n",
+    "print(f\"... Trotterized Circuit, K={K}, t={t}\")\n",
+    "if num_qubits < 11:\n",
+    "    if hamiltonian_name != '':\n",
+    "        hamlib_simulation_kernel.kernel_draw(qc, method=1)\n",
+    "    else:\n",
+    "        print(qc)\n",
+    "else:\n",
+    "    print(\"  ... circuit is too large to draw.\")\n",
+    "\n",
+    "print(\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Create Measurement Circuits from Base Circuit and Pauli Terms\n",
+    "Here, we append basis rotation gates for each Pauli Term group to the base evolution circuit to create an array of circuits for execution."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "... Created 2 circuits, one for each group:\n",
+      "[('ZZIIII', (1+0j)), ('ZIIIIZ', (1+0j)), ('IZZIII', (1+0j)), ('IIIIZZ', (1+0j)), ('IIZZII', (1+0j)), ('IIIZZI', (1+0j))]\n",
+      "[('XIIIII', (2+0j)), ('IXIIII', (2+0j)), ('IIIIIX', (2+0j)), ('IIXIII', (2+0j)), ('IIIXII', (2+0j)), ('IIIIXI', (2+0j))]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# generate an array of circuits, one for each pauli_string in list\n",
+    "circuits = hamlib_simulation_kernel.create_circuits_for_pauli_terms(qc, num_qubits, pauli_str_list)\n",
+    "\n",
+    "print(f\"... Created {len(circuits)} circuits, one for each group:\")               \n",
+    "for circuit, group in list(zip(circuits, pauli_term_groups)):\n",
+    "    print(group)\n",
+    "    #print(circuit)\n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Execute Circuits to Produce Measurement Distributions\n",
+    "For now, we execute using the Aer simulator. This will be enhanced to use the QED-C execution module to enable execution on multiple programming APIs and backend systems. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "... begin executing 2 circuits ...\n",
+      "... finished executing 2 circuits, total execution time = 0.014 sec.\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Initialize simulator backend\n",
+    "from qiskit_aer import Aer\n",
+    "backend = Aer.get_backend('qasm_simulator')\n",
+    "\n",
+    "print(f\"... begin executing {len(circuits)} circuits ...\")\n",
+    "ts = time.time()\n",
+    "\n",
+    "# Execute all of the circuits to obtain array of result objects\n",
+    "results = backend.run(circuits, num_shots=num_shots).result()\n",
+    "\n",
+    "exec_time = round(time.time()-ts, 3)\n",
+    "print(f\"... finished executing {len(circuits)} circuits, total execution time = {exec_time} sec.\\n\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compute the Energy of the Evolved State from the Hamiltonian and the Measurement Distributions\n",
+    "Here, we process the measurement results from circuit execution using the Hamiltonian terms to compute the expectation value of the energy observable.\n",
+    "\n",
+    "We also, retain the contributions from each terms so that we can use those in calcuating other observables from the same measurement results."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "... begin computing observable value ...\n",
+      "... finished computing observable value, computation time = 0.001 sec.\n",
+      "\n",
+      "    Total Energy: -5.5664\n",
+      "\n",
+      "    Term Contributions: {'ZZIIII': -0.962890625, 'ZIIIIZ': -0.96484375, 'IZZIII': -0.955078125, 'IIIIZZ': -0.958984375, 'IIZZII': -0.9609375, 'IIIZZI': -0.958984375, 'XIIIII': -0.001953125, 'IXIIII': -0.01953125, 'IIIIIX': 0.0234375, 'IIXIII': 0.03515625, 'IIIXII': 0.02734375, 'IIIIXI': 0.033203125}\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Compute the total energy for the Hamiltonian\n",
+    "\n",
+    "print(f\"... begin computing observable value ...\")\n",
+    "ts = time.time()\n",
+    "\n",
+    "total_energy, term_contributions = observables.calculate_expectation_from_measurements(\n",
+    "                                            num_qubits, results, pauli_term_groups)\n",
+    "obs_time = round(time.time()-ts, 3)\n",
+    "print(f\"... finished computing observable value, computation time = {obs_time} sec.\\n\")\n",
+    "\n",
+    "print(f\"    Total Energy: {round(np.real(total_energy), 4)}\\n\")\n",
+    "print(f\"    Term Contributions: {term_contributions}\\n\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compute Energy of the Evolved State Classically and Compare to Quantum Result\n",
+    "Here, we use a classical computation to determine the exact expectation value and produce a quality score for the quantum computation."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "... begin classical computation of expectation value ...\n",
+      "... exact computation time = 0.012 sec\n",
+      "\n",
+      "Exact expectation value, computed classically: -6.0\n",
+      "Estimated expectation value, computed using quantum algorithm: -5.5664\n",
+      "\n",
+      "    ==> Simulation Quality: 0.928\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "print(f\"... begin classical computation of expectation value ...\")\n",
+    "                    \n",
+    "ts = time.time()\n",
+    "\n",
+    "correct_exp, correct_dist = evolution_exact.compute_expectation_exact(\n",
+    "        init_state,\n",
+    "        observables.ensure_pauli_terms(sparse_pauli_terms, num_qubits),\n",
+    "        1.0            # time\n",
+    "        )\n",
+    "    \n",
+    "exact_time = round(time.time()-ts, 3)\n",
+    "print(f\"... exact computation time = {exact_time} sec\")\n",
+    "\n",
+    "print(f\"\\nExact expectation value, computed classically: {round(np.real(correct_exp), 4)}\")\n",
+    "print(f\"Estimated expectation value, computed using quantum algorithm: {round(np.real(total_energy), 4)}\\n\")\n",
+    "\n",
+    "simulation_quality = round(np.real(total_energy) / np.real(correct_exp), 3)\n",
+    "print(f\"    ==> Simulation Quality: {np.real(simulation_quality)}\\n\")\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compute Expectation with Estimator\n",
+    "Here, we do a sanity check on the above processes by comparing with energy obtained using the Qiskit Estimator."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "... Estimator computation time = 0.003 sec\n",
+      "Expectation value, computed using Qiskit Estimator: -5.7632\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Call the Qiskit Estimator using the function wrapper in 'observables' module.\n",
+    "\n",
+    "# DEVNOTE: We may want to surface the actual Estimator call instead. \n",
+    "\n",
+    "# Ensure that the pauli_terms are in 'full' format, not 'sparse' - convert if necessary\n",
+    "pauli_terms = observables.ensure_pauli_terms(sparse_pauli_terms, num_qubits=num_qubits)\n",
+    "pauli_terms = observables.swap_pauli_list(pauli_terms)\n",
+    "\n",
+    "ts = time.time()\n",
+    "\n",
+    "estimator_energy = observables.estimate_expectation_with_estimator(backend, qc, pauli_terms, num_shots=num_shots)\n",
+    "\n",
+    "estimator_time = round(time.time()-ts, 3)\n",
+    "print(f\"... Estimator computation time = {estimator_time} sec\")\n",
+    "\n",
+    "print(f\"Expectation value, computed using Qiskit Estimator: {round(np.real(estimator_energy), 4)}\\n\")\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Compute expectation value of other observables.\n",
+    "WORK-IN-PROGRESS: This code attempts to derive spin correlation and magenetization Hamiltonians from the Hamiltonian under test.\n",
+    "We do not currently check whether the terms actually make sense.  We also do not consider other observable types at this point."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hamiltonian under test:\n",
+      "[[('ZZIIII', (1+0j)), ('ZIIIIZ', (1+0j)), ('IZZIII', (1+0j)), ('IIIIZZ', (1+0j)), ('IIZZII', (1+0j)), ('IIIZZI', (1+0j))], [('XIIIII', (2+0j)), ('IXIIII', (2+0j)), ('IIIIIX', (2+0j)), ('IIXIII', (2+0j)), ('IIIXII', (2+0j)), ('IIIIXI', (2+0j))]]\n",
+      "\n",
+      "****\n",
+      "... mean spin correlation terms:  [('IIIIZZ', (0.2+0j)), ('IIIZZI', (0.2+0j)), ('IIZZII', (0.2+0j)), ('IZZIII', (0.2+0j)), ('ZZIIII', (0.2+0j))]\n",
+      "****\n",
+      "... magnetization terms:  [('IIIIIZ', (1+0j)), ('IIIIZI', (1+0j)), ('IIIZII', (1+0j)), ('IIZIII', (1+0j)), ('IZIIII', (1+0j)), ('ZIIIII', (1+0j))]\n",
+      "\n",
+      "Spin Correlation: -0.959\n",
+      "WARN: term not found in term_contributions: IIIIIZ\n",
+      "WARN: term not found in term_contributions: IIIIZI\n",
+      "WARN: term not found in term_contributions: IIIZII\n",
+      "WARN: term not found in term_contributions: IIZIII\n",
+      "WARN: term not found in term_contributions: IZIIII\n",
+      "WARN: term not found in term_contributions: ZIIIII\n",
+      "Magnetization: 0.0\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "\n",
+    "print(f\"Hamiltonian under test:\")\n",
+    "print(pauli_term_groups)\n",
+    "print(\"\")\n",
+    "\n",
+    "################\n",
+    "### DEVNOTE: We don't want to use SparsePauliOp if possible\n",
+    "\n",
+    "from qiskit.quantum_info import SparsePauliOp\n",
+    "\n",
+    "# need to check if the below terms are actually in the Hamiltonian\n",
+    "\n",
+    "L = num_qubits\n",
+    "\n",
+    "# this doesn't include the Z's at the ends of the chain; OK, if we assume an open chain\n",
+    "print(\"****\")\n",
+    "correlation_op = SparsePauliOp.from_sparse_list(\n",
+    "    [(\"ZZ\", [i, i + 1], 1.0) for i in range(0, L - 1)],\n",
+    "    num_qubits=L\n",
+    ") / (L - 1)\n",
+    "H_terms_spin_correlation = correlation_op.to_list()\n",
+    "print(\"... mean spin correlation terms: \", H_terms_spin_correlation)\n",
+    "\n",
+    "print(\"****\")\n",
+    "magnetization_op = SparsePauliOp.from_sparse_list(\n",
+    "    #[(\"Z\", [i], 1.0) for i in range(0, 6)], num_qubits=6\n",
+    "    [(\"Z\", [i], 1.0) for i in range(0, L)], num_qubits=L\n",
+    ")\n",
+    "H_terms_magnetization = magnetization_op.to_list()\n",
+    "print(\"... magnetization terms: \", H_terms_magnetization)\n",
+    "\n",
+    "print(\"\")\n",
+    "\n",
+    "spin_correlation = observables.calculate_expectation_from_contributions(term_contributions, H_terms_spin_correlation)\n",
+    "print(f\"Spin Correlation: {round(np.real(spin_correlation), 3)}\")\n",
+    "\n",
+    "magnetization = observables.calculate_expectation_from_contributions(term_contributions, H_terms_magnetization)\n",
+    "print(f\"Magnetization: {round(np.real(magnetization), 3)}\")\n",
+    "\n",
+    "print(\"\")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3.12",
+   "language": "python",
+   "name": "python312"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/hamlib/generate_pauli_groups.py
+++ b/hamlib/generate_pauli_groups.py
@@ -1,0 +1,171 @@
+import os
+import math
+import numpy as np
+# Configure module paths
+import sys
+sys.path.insert(1, "_common")
+sys.path.insert(1, "qiskit")
+
+from hamlib_utils import load_hamlib_file, get_hamlib_sparsepaulilist
+from hamlib_simulation_kernel import ensure_sparse_pauli_op
+
+
+# 'H2': '/ham_BK-4'
+X = np.array([[0, 1], [1, 0]])
+Y = np.array([[0, -1j], [1j, 0]])
+Z = np.array([[1, 0], [0, -1]])
+I = np.eye(2)
+
+pauli_map = {
+    'I' : I,
+    'X' : X,
+    'Z' : Z,
+    'Y' : Y
+}
+
+def pauli_string_to_string(pauli_string, qubits):
+    """Convert a PauliString to a string representation with 'I' for identity."""
+    #print(f"... pauli_string_to_string({pauli_string}, {qubits}")
+    result = []
+    for qubit in qubits:
+        if qubit in pauli_string.keys():
+            result.append(str(pauli_string[qubit]))
+        else:
+            result.append('-')
+    #print(f"... result = {result}")
+    return result
+
+def compute_groups(num_qubits: int, sparse_pauli_list: list, k: int):
+    return get_si_sets(num_qubits, sparse_pauli_list, k)
+
+def compute_blocks(qubits, k):
+    return [qubits[k * i: k * (i + 1)] for i in range(math.ceil(len(qubits) / k))]
+
+def dict_to_string(input_dic: dict, num_qubits: int):
+    """
+    Convert the dictionary representation of pauli string to a string
+    eg. n = 4, {0: 'Z', 1: 'Z'} -> 'ZZII'
+    """
+    output_string = ''
+    for i in range(num_qubits):
+        if i in input_dic.keys():
+            output_string += input_dic[i]
+        else:
+            output_string += 'I'
+    return output_string
+
+def get_terms_ordered_by_abscoeff(sparse_pauli_list:list, num_qubits: int) -> list:
+    """Returns the terms of the PauliSum ordered by coefficient absolute value.
+
+    Args:
+        ham: A PauliSum.
+    Returns:
+        a list of PauliStrings sorted by the absolute value of their coefficient.
+    """
+    sorted_data = sorted(sparse_pauli_list, key=lambda x: abs(x[1]), reverse=True)
+    sorted_pauli_terms = [dict_to_string(x[0], num_qubits) for x in sorted_data]
+    return sorted_pauli_terms
+
+def restrict_to(
+        pauli: str, qubits: list[int]
+) -> str:
+    """Returns the Pauli string restricted to the provided qubits.
+
+    Arguments:
+        pauli: A Pauli string.
+        qubits: A set of qubits.
+
+    Returns:
+        The provided Pauli string acting only on the provided qubits.
+        Note: This could potentially be empty (identity).
+    """
+    new_pauli_strings = ''
+    for idx, p in enumerate(pauli):
+        if idx in qubits:
+            new_pauli_strings += p
+    return new_pauli_strings
+
+def pauli_string_to_matrix(pauli_str: str) -> np.array:
+    """
+    Converts a Pauli string (like 'XYZ') to the corresponding matrix.
+    """
+    result = pauli_map[pauli_str[0]]
+    for p in pauli_str[1:]:
+        result = np.kron(result, pauli_map[p])
+    return result
+
+def if_commute(pauli1: str, pauli2: str, atol=1e-8) -> bool:
+    """
+    Checks if the pauli1(A) and pauli2(B) commutes.
+    if AB-BA < atol, they commute.
+    """
+    mat1 = pauli_string_to_matrix(pauli1)
+    mat2 = pauli_string_to_matrix(pauli2)
+    # calculate the commutator
+    commutator = mat1 @ mat2 - mat2 @ mat1
+    if np.allclose(commutator, np.zeros_like(commutator), atol=atol):
+        return True # they commute
+    else:
+        return False # they don't commute
+
+def commutes(pauli1: str, pauli2: str, blocks) -> bool:
+    """Returns True if pauli1 k-commutes with pauli2, else False.
+
+    Arguments:
+        pauli1: A Pauli string.
+        pauli2: A Pauli string.
+        blocks: The block partitioning.
+
+    """
+
+    for block in blocks:
+        if not if_commute(restrict_to(pauli1, block), restrict_to(pauli2, block)):
+            return False
+    return True
+
+def get_si_sets(num_qubits:int, sparse_pauli_list, k: int = 1) -> list[list[str]]:
+    """Returns grouping from the sorted insertion algorithm [https://quantum-journal.org/papers/q-2021-01-20-385/].
+
+    Args:
+        op: The observable to group.
+        k: The integer k in k-commutativity.
+    """
+
+    blocks = compute_blocks(list(range(num_qubits)), k)
+
+    commuting_sets = []
+    for pstring in get_terms_ordered_by_abscoeff(sparse_pauli_list, num_qubits):
+        found_commuting_set = False
+
+        for commset in commuting_sets:
+            cant_add = False
+
+            for pauli in commset:
+                if not commutes(pstring, pauli, blocks):
+                    cant_add = True
+                    break
+
+            if not cant_add:
+                commset.append(pstring)
+                found_commuting_set = True
+                break
+
+        if not found_commuting_set:
+            commuting_sets.append([pstring])
+
+    return commuting_sets
+
+# hamiltonian_name = 'chemistry/electronic/standard/H2'
+# hamiltonian_params = { "ham_BK": '' }
+# num_qubits = 4
+
+# # load the HamLib file for the given hamiltonian name
+# load_hamlib_file(filename=hamiltonian_name)
+
+# # return a sparse Pauli list of terms queried from the open HamLib file
+# sparse_pauli_terms, dataset_name = get_hamlib_sparsepaulilist(num_qubits=num_qubits, params=hamiltonian_params)
+# print(f"... sparse_pauli_terms = \n{sparse_pauli_terms}")
+
+
+# k = num_qubits
+# print(compute_groups(num_qubits, sparse_pauli_terms, k))


### PR DESCRIPTION
In `generate_pauli_groups.py`, it contains all the functions to generate k-commuting groups, which do not depend on Cirq, Openfermion, or Qiskit.

In `benchmark_hamlib_observables_custom-group.ipynb`, it uses 
`from generate_pauli_groups import compute_groups`
to generate commuting groups.