### PR TITLE
Add MPI support for QPE, QFT, and Hamlib

### DIFF
--- a/_common/cudaq/execute.py
+++ b/_common/cudaq/execute.py
@@ -26,6 +26,7 @@
 import os, sys
 import time
 import copy
+import qcb_mpi as mpi
 
 # import metrics module relative to top level of package
 current_dir = os.path.dirname(os.path.abspath(__file__))
@@ -140,7 +141,11 @@ def set_execution_target(backend_id=None, provider_backend=None,
         backend = provider_backend
     
     # now set the execution target to the given backend_id
-    cudaq.set_target(backend_id)
+    if mpi.enabled():
+        option_string="mgpu,fp32"
+    else:
+        option_string="fp32"
+    cudaq.set_target(backend_id, option=option_string)
     
     # create an informative device name used by the metrics module
     device_name = backend_id

--- a/_common/metrics.py
+++ b/_common/metrics.py
@@ -36,7 +36,7 @@ from datetime import datetime
 import traceback
 import matplotlib.cm as cm
 import copy
-
+import qcb_mpi as mpi
 # Raw and aggregate circuit metrics
 circuit_metrics = {  }
 
@@ -451,7 +451,8 @@ def report_metrics_for_group (group):
 def report_metrics ():   
     # loop over all groups and print metrics for that group
     for group in circuit_metrics:
-        report_metrics_for_group(group)
+        if mpi.leader():
+            report_metrics_for_group(group)
 
        
 # Aggregate and report on metrics for the given groups, if all circuits in group are complete
@@ -472,8 +473,9 @@ def finalize_group(group, report=True):
     #print(f"  ... group_done = {group} {group_done}")
     if group_done and report:
         aggregate_metrics_for_group(group)
-        print("************")
-        report_metrics_for_group(group)
+        if mpi.leader():
+            print("************")
+            report_metrics_for_group(group)
         
     # sort the group metrics (sometimes they come back out of order)
     sort_group_metrics()
@@ -518,8 +520,9 @@ def finalize_group_2_level(group):
         process_circuit_metrics_2_level(group)
         
         aggregate_metrics_for_group(group)
-        print("************")
-        report_metrics_for_group(group)
+        if mpi.leader():
+            print("************")
+            report_metrics_for_group(group)
         
     # sort the group metrics (sometimes they come back out of order)
     sort_group_metrics()

--- a/_common/qcb_mpi.py
+++ b/_common/qcb_mpi.py
@@ -1,0 +1,120 @@
+# SPDX-FileCopyrightText: Copyright (c) <year> NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##########################
+# QCB MPI Module
+#
+# This module allows for MPI support when the mpi4py module is loaded from
+# the python command-line. When the module is not loaded, the same 
+# data and functions are available for single task execution without MPI
+#
+
+import os
+import sys
+
+rank = 0
+size = 1
+initialized = False
+
+##########################################################################
+# MPI is enabled by adding by loading the mpi4py module
+# - This can be accomplished, for example, with
+# - "-m mpy4py" as an argument to python
+# If MPI is not enabled, wrapper functions provide the same
+# functionality without any MPI calls
+##########################################################################
+if "mpi4py" not in sys.modules:
+    def enabled():
+        return False
+
+    # Return true if this task is rank 0
+    def leader():
+        return True
+    
+    # Synchronize all MPI Tasks
+    def barrier():
+        return
+
+    # Broadcast data from leader
+    def bcast(data):
+        return data
+
+    # Initialize this module
+    # -- stdout is redirected to null if not the leader
+    def init():
+        global rank, size, leader, initialized
+        if initialized:
+            return
+        
+        print("Initializing MPI...No MPI Module Loaded",flush=True)        
+        rank = 0
+        size = 0
+        initialized = True
+
+else:
+    from mpi4py import MPI
+    import atexit
+
+    def enabled():
+        return True
+
+    def leader():
+        global initialized, rank
+        if initialized is False:
+            raise Exception("MPI call before init")
+        if rank == 0:
+            return True
+        else:
+            return False
+
+    def barrier():
+        global initialized
+        if initialized is False:
+            raise Exception("MPI call before init")
+        MPI.COMM_WORLD.barrier()
+        return
+
+    def bcast(data):
+        return MPI.COMM_WORLD.bcast(data, root=0)
+
+    def finalize():
+        global rank, initialized
+
+        # Close null file used for capturing stdout
+        if rank > 0 and initialized:
+            sys.stdout.close()
+        initialized = False
+
+    def init():
+        global rank, size, initialized
+        if initialized:
+            return
+        
+        rank = MPI.COMM_WORLD.Get_rank()
+        if rank == 0:
+            print("Initializing MPI...",flush=True,end='')
+        size = MPI.COMM_WORLD.Get_size()
+        MPI.COMM_WORLD.barrier()
+        initialized = True
+
+        # Capture duplicate output from non-leader ranks
+        if rank == 0:
+            print("Using",size,"tasks",flush=True)
+        else:
+            f = open(os.devnull, 'w')
+            sys.stdout = f
+
+        atexit.register(finalize)
+        return

--- a/phase-estimation/pe_benchmark.py
+++ b/phase-estimation/pe_benchmark.py
@@ -25,6 +25,10 @@ def qedc_benchmarks_init(api: str = "qiskit"):
 	api_dir = os.path.abspath(os.path.join(common_dir, f"{api}"))
 	sys.path = [api_dir] + [p for p in sys.path if p != api_dir]
 
+	import qcb_mpi as mpi
+	globals()["mpi"] = mpi
+	mpi.init()
+
 	import execute as ex
 	globals()["ex"] = ex
 
@@ -188,6 +192,7 @@ def run(min_qubits=3, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=100
 				theta = init_phase
 		
 			# create the circuit for given qubit size and theta, store time metric
+			mpi.barrier()
 			ts = time.time()
 			qc = PhaseEstimation(num_qubits, theta)
 			metrics.store_metric(num_qubits, theta, 'create_time', time.time() - ts)
@@ -203,11 +208,12 @@ def run(min_qubits=3, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=100
 
 	##########
 
-	# draw a sample circuit
-	kernel_draw()
+	if mpi.leader():
+		# draw a sample circuit
+		kernel_draw()
 
-	# Plot metrics for all circuit sizes
-	metrics.plot_metrics(f"Benchmark Results - {benchmark_name} - Qiskit")
+		# Plot metrics for all circuit sizes
+		metrics.plot_metrics(f"Benchmark Results - {benchmark_name} - Qiskit")
 
 
 #######################

--- a/quantum-fourier-transform/qft_benchmark.py
+++ b/quantum-fourier-transform/qft_benchmark.py
@@ -28,6 +28,10 @@ def qedc_benchmarks_init(api: str = "qiskit"):
     api_dir = os.path.abspath(os.path.join(common_dir, f"{api}"))
     sys.path = [api_dir] + [p for p in sys.path if p != api_dir]
 
+    import qcb_mpi as mpi
+    globals()["mpi"] = mpi
+    mpi.init()
+
     import execute as ex
     globals()["ex"] = ex
 
@@ -226,6 +230,7 @@ def run (min_qubits=2, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=10
             if verbose: print(f"... s_int={s_int} bitset={bitset}")
             
             # create the circuit for given qubit size and secret string, store time metric
+            mpi.barrier()
             ts = time.time()
             qc = QuantumFourierTransform(num_qubits, s_int, bitset, method)       
             metrics.store_metric(input_size, s_int, 'create_time', time.time()-ts)
@@ -241,11 +246,12 @@ def run (min_qubits=2, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=10
        
     ##########
     
-    # draw a sample circuit
-    kernel_draw()
+    if mpi.leader():
+        # draw a sample circuit
+        kernel_draw()
 
-    # Plot metrics for all circuit sizes                         
-    metrics.plot_metrics(f"Benchmark Results - {benchmark_name} ({method}) - Qiskit")
+        # Plot metrics for all circuit sizes                         
+        metrics.plot_metrics(f"Benchmark Results - {benchmark_name} ({method}) - Qiskit")
 
 #######################
 # MAIN


### PR DESCRIPTION
This adds initial MPI simulation support to the observables-work branch for QPE, QFT, and Hamlib benchmarks.

MPI is enabled by loading the mpi4py module when invoking python. E.g. `python3 qft_benchmark.py -a cudaq -n 33 -c 1` would become `mpirun -np 2 python3 -m mpi4py qft_benchmark.py -a cudaq -s 1000 -n 33 -c 1`

When the mpi4py module is not loaded, stub functions are used for single-process execution as before without any requirement for an MPI library.

stdout is captured for all but the leader MPI task to avoid duplicate output.

