### PR TITLE
Support Qiskit 2

### DIFF
--- a/hhl/qiskit/hhl_benchmark.py
+++ b/hhl/qiskit/hhl_benchmark.py
@@ -564,10 +564,12 @@ def true_distr(A, b=0):
 def postselect(outcomes, return_probs=True):
     
     mar_out = {}
-    for b_str in outcomes:
+    for b_str, counts in outcomes.items():
+        # SamplerV2 result does not include white spaces between classical registers
+        # E.g., backend.run: "0 0", SamplerV2: "00"
+        b_str = b_str.replace(" ", "")
         if b_str[0] == '1':
-            counts = outcomes[b_str]
-            mar_out[b_str[2:]] = counts
+            mar_out[b_str[1:]] = counts
             
     # compute postselection rate
     ps_shots = sum(mar_out.values())
@@ -852,4 +854,3 @@ def run2 (min_input_qubits=1, max_input_qubits=3, skip_qubits=1,
 
 # if main, execute method
 if __name__ == '__main__': run()
-   

--- a/shors/qiskit/shors_benchmark.py
+++ b/shors/qiskit/shors_benchmark.py
@@ -243,7 +243,8 @@ def ShorsAlgorithm(number, base, method, verbose=verbose):
             qc.barrier()
 
             # Reset the counting qubit to 0 if the previous measurement was 1
-            qc.x(qr_counting).c_if(cr_aux,1)
+            with qc.if_test((cr_aux,1)):
+                qc.x(qr_counting)
             qc.h(qr_counting)
 
             cUa_gate = controlled_Ua(n, base,2**(2*n-1-k), number)
@@ -255,7 +256,8 @@ def ShorsAlgorithm(number, base, method, verbose=verbose):
 
             # perform inverse QFT --> Rotations conditioned on previous outcomes
             for i in range(2**k):
-                qc.p(getAngle(i, k), qr_counting[0]).c_if(cr_data, i)
+                with qc.if_test((cr_data, i)):
+                    qc.p(getAngle(i, k), qr_counting[0])
 
             qc.h(qr_counting)
             qc.measure(qr_counting[0], cr_data[k])


### PR DESCRIPTION
This PR includes changes to support Qiskit 2.0

- add new backend_id "aer_sampler" to test circuits with mid-circuit measurement locally
- join sampler results for all classical bits to support benchmarks with multiple classical registers (e.g., HHL)
- show an error message if an error occurred during `job.result()` (such as error during real device execution)
- fix `transpiler_seed` to make benchmarks reproducible
- fix HHL benchmark to deal with SamplerV2 result (i.e., no white space between classical registers)
- replace `c_if` with `if_test` because Qiskit 2 removed `c_if`.

I discovered an issue #692.