### PR TITLE
Fixing Hamlib Method 3 Crash

### DIFF
--- a/bernstein-vazirani/bv_benchmark.py
+++ b/bernstein-vazirani/bv_benchmark.py
@@ -101,7 +101,7 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
 		method=1, input_value=None,
 		backend_id=None, provider_backend=None,
 		hub="ibm-q", group="open", project="main", exec_options=None,
-		context=None, api=None):
+		context=None, api=None, get_circuits=False):
 
 	# configure the QED-C Benchmark package for use with the given API
 	BersteinVazirani, kernel_draw = qedc_benchmarks_init(api)
@@ -121,6 +121,9 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
 	
 	# Variable for new qubit group ordering if using mid_circuit measurements
 	mid_circuit_qubit_group = []
+
+	# Variable to store all created circuits to return
+	all_qcs = []
 
 	# If using mid_circuit measurements, set transform qubit group to true
 	transform_qubit_group = True if method == 2 else False
@@ -156,7 +159,10 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
 		# determine number of circuits to execute for this group
 		num_circuits = min(2**(input_size), max_circuits)
 		
-		print(f"************\nExecuting [{num_circuits}] circuits with num_qubits = {num_qubits}")
+		if not get_circuits:
+			print(f"************\nExecuting [{num_circuits}] circuits with num_qubits = {num_qubits}")
+		else:
+			print(f"************\nCreating [{num_circuits}] circuits with num_qubits = {num_qubits}")
 		
 		# determine range of secret strings to loop over
 		if 2**(input_size) <= max_circuits:
@@ -183,6 +189,11 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
 			if method == 2:
 				mid_circuit_qubit_group.append(2)
 			
+			# If we only want the circuits:
+			if get_circuits:	
+				all_qcs.append(BersteinVazirani(num_qubits, s_int, bitset, method))
+				continue
+			
 			# create the circuit for given qubit size and secret string, store time metric
 			ts = time.time()
 			qc = BersteinVazirani(num_qubits, s_int, bitset, method)	   
@@ -192,8 +203,14 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
 			ex.submit_circuit(qc, num_qubits, s_int, shots=num_shots)
 			  
 		# Wait for some active circuits to complete; report metrics when groups complete
-		ex.throttle_execution(metrics.finalize_group)  
-		
+		if not get_circuits:
+			ex.throttle_execution(metrics.finalize_group)  
+	
+	# Early return if we just want the circuits
+	if get_circuits:
+		print(f"Returning circuits")
+		return all_qcs
+
 	# Wait for all active circuits to complete; report metrics when groups complete
 	ex.finalize_execution(metrics.finalize_group)
 	   

--- a/bernstein-vazirani/bv_benchmark.py
+++ b/bernstein-vazirani/bv_benchmark.py
@@ -208,7 +208,7 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
 	
 	# Early return if we just want the circuits
 	if get_circuits:
-		print(f"Returning circuits")
+		print(f"************\nReturning circuits")
 		return all_qcs
 
 	# Wait for all active circuits to complete; report metrics when groups complete

--- a/hamlib/qiskit/hamlib_simulation_kernel.py
+++ b/hamlib/qiskit/hamlib_simulation_kernel.py
@@ -406,8 +406,10 @@ def create_circuit_from_op(
         QCI_ = i_state
     
     # Append K trotter steps
+    evo_inverse = [x.inverse() for x in evo]
+    
     circuit = append_trotter_steps(num_trotter_steps,
-            evo if not use_inverse_flag else evo.inverse(),
+            evo if not use_inverse_flag else evo_inverse,
             num_qubits,
             circuit)
 
@@ -417,9 +419,9 @@ def create_circuit_from_op(
 
     # append simple inverse Trotter steps if method 3
     if method == 3:  
-        inv = evo.inverse()
-        inv.name = "e^iHt"
-        circuit = append_trotter_steps(num_trotter_steps, inv, ham_op, circuit)
+        inv = evo_inverse
+        for x in inv: x.name = "e^iHt"
+        circuit = append_trotter_steps(num_trotter_steps, inv, ham_op.num_qubits, circuit)
         if num_qubits <= 6:
             INV_ = inv
         


### PR DESCRIPTION
The purpose of this pull request is to track the changes made while collaborating with Sandia. 
### Changes Made:

1. An example of modifying the run method to return the circuits in Bernstein-Vazirani (BV). 
2. Fixing the bug in Hamlib method 3. 

### Notes:

- Still need to verify that the bug fixes give the same results as the published paper.
- Still need to add metadata when returning the circuits for BV; for example, the secret string, number of qubits, etc. for each circuit returned.