### PR TITLE
Fixing Hamlib Method 3 Crash

### DIFF
--- a/hamlib/qiskit/hamlib_simulation_kernel.py
+++ b/hamlib/qiskit/hamlib_simulation_kernel.py
@@ -421,7 +421,7 @@ def create_circuit_from_op(
     if method == 3:  
         inv = evo_inverse
         for x in inv: x.name = "e^iHt"
-        circuit = append_trotter_steps(num_trotter_steps, inv, ham_op.num_qubits, circuit)
+        circuit = append_trotter_steps(num_trotter_steps, inv, num_qubits, circuit)
         if num_qubits <= 6:
             INV_ = inv
         


### PR DESCRIPTION
The purpose of this pull request is to fix Hamlib method 3 from crashing. 
### Changes Made:

1. We used the inverse of the gates within _evo_ instead of trying to inverse the list itself
2. We renamed each gate within the list instead of trying to rename the list itself
3. We passed in the number of qubits instead of the operator to _append_trotter_steps()_ to avoid a type error.

### Notes:

- Verified that the results match the previous results. 