### PR TITLE
Get Bernstein-Vazirani Qiskit Circuits

### DIFF
--- a/bernstein-vazirani/bv_benchmark.py
+++ b/bernstein-vazirani/bv_benchmark.py
@@ -189,15 +189,16 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
 			if method == 2:
 				mid_circuit_qubit_group.append(2)
 			
-			# If we only want the circuits:
-			if get_circuits:	
-				all_qcs.append(BersteinVazirani(num_qubits, s_int, bitset, method))
-				continue
-			
 			# create the circuit for given qubit size and secret string, store time metric
 			ts = time.time()
 			qc = BersteinVazirani(num_qubits, s_int, bitset, method)	   
 			metrics.store_metric(num_qubits, s_int, 'create_time', time.time()-ts)
+
+			# If we only want the circuits:
+			if get_circuits:	
+				all_qcs.append(qc)
+				# Continue to skip sumbitting the circuit for execution. 
+				continue
 			
 			# submit circuit for execution on target (simulator, cloud simulator, or hardware)
 			ex.submit_circuit(qc, num_qubits, s_int, shots=num_shots)

--- a/bernstein-vazirani/bv_benchmark.py
+++ b/bernstein-vazirani/bv_benchmark.py
@@ -165,8 +165,6 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
 			print(f"************\nExecuting [{num_circuits}] circuits with num_qubits = {num_qubits}")
 		else:
 			print(f"************\nCreating [{num_circuits}] circuits with num_qubits = {num_qubits}")
-			hold_qcs = []
-			hold_qcs_info = []
 		
 		# determine range of secret strings to loop over
 		if 2**(input_size) <= max_circuits:
@@ -201,8 +199,8 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
 
 			# If we only want the circuits:
 			if get_circuits:	
-				hold_qcs.append(qc)
-				hold_qcs_info.append({ 
+				all_qcs.append(qc)
+				all_qcs_info.append({ 
 					"secret_string": s_int, 
 					"num_qubits": num_qubits,
 					"create_time": create_time,
@@ -216,14 +214,10 @@ def run (min_qubits=3, max_qubits=6, skip_qubits=1, max_circuits=3, num_shots=10
 		# Wait for some active circuits to complete; report metrics when groups complete
 		if not get_circuits:
 			ex.throttle_execution(metrics.finalize_group)
-		else:
-			all_qcs.append(hold_qcs) 
-			all_qcs_info.append(hold_qcs_info) 
 	
 	# Early return if we just want the circuits
 	if get_circuits:
-		print(f"************\nReturning circuits")
-		# Returns circuits and their information in 2-D list 
+		print(f"************\nReturning circuits and circuit information")
 		return all_qcs, all_qcs_info
 
 	# Wait for all active circuits to complete; report metrics when groups complete


### PR DESCRIPTION
The purpose of this pull request is to modify the Bernstein-Vazirani benchmark to optionally return qiskit circuits.

### Changes Made:

1. Added _get_circuits_ flag to the run method.
2. Added variables to store circuits and their creation information
3. Added an early return to avoid executing circuits. 

### Files Modified:

- bernstein-vazirani/bv_benchmark.py