### PR TITLE
New Structure For Returned Phase-Estimation Circuits

### DIFF
--- a/phase-estimation/pe_benchmark.py
+++ b/phase-estimation/pe_benchmark.py
@@ -144,7 +144,7 @@ def run(min_qubits=3, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=100
 
 	# Variable to store all created circuits to return
 	if get_circuits:
-		all_qcs = []
+		all_qcs = {}
 
 	# Define custom result handler
 	def execution_handler(qc, result, num_qubits, theta, num_shots):
@@ -179,7 +179,9 @@ def run(min_qubits=3, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=100
 			print(f"************\nExecuting [{num_circuits}] circuits with num_qubits = {num_qubits}")
 		else:
 			print(f"************\nCreating [{num_circuits}] circuits with num_qubits = {num_qubits}")
-		
+			# Initialize dictionary to store circuits for this qubit group. 
+			all_qcs[str(num_qubits)] = {}
+
 		# determine range of secret strings to loop over
 		if 2**(num_counting_qubits) <= max_circuits:
 			theta_choices = list(range(num_circuits))
@@ -206,7 +208,7 @@ def run(min_qubits=3, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=100
 
 			# Store each circuit if we want to return them
 			if get_circuits:
-				all_qcs.append(qc)
+				all_qcs[str(num_qubits)][str(theta)] = qc
 				# Continue to skip sumbitting the circuit for execution. 
 				continue
 			


### PR DESCRIPTION
### Changes Made:

1. Changed `all_qcs` from a list to a dictionary.
2. Added sub dictionaries to `all_qcs` to match the structure of `metrics.circuit_metrics`.

The returned circuits are `dict[str, dict[str, QuantumCircuit]]` and the information is still returned as the metrics module.

### Test Case:
<img width="1133" alt="Code" src="https://github.com/user-attachments/assets/c2372408-3abf-46cd-9c58-de34cf92d3d3" />
<img width="898" alt="Output" src="https://github.com/user-attachments/assets/cc957109-dbcf-4ec9-8865-6e7b9e43859b" />

Code and Output Text: [PE_Output.txt](https://github.com/user-attachments/files/20873357/PE_Output.txt)