### PR TITLE
 Dynamic circuits (Dynamic Inverse QFT) with Phase Estimation 

### DIFF
--- a/phase-estimation/cudaq/pe_kernel.py
+++ b/phase-estimation/cudaq/pe_kernel.py
@@ -89,9 +89,9 @@ def pe_kernel (num_qubits: int, theta: float, use_midcircuit_measurement: bool):
     mz(counting_qubits)
         
  
-def PhaseEstimation (num_qubits: int, theta: float):
+def PhaseEstimation (num_qubits: int, theta: float, use_midcircuit_measurement: bool):
 
-    qc = [pe_kernel, [num_qubits, theta]]
+    qc = [pe_kernel, [num_qubits, theta, use_midcircuit_measurement]]
     
     global QC_
     if num_qubits <= 6:

--- a/phase-estimation/cudaq/pe_kernel.py
+++ b/phase-estimation/cudaq/pe_kernel.py
@@ -47,7 +47,7 @@ def iqft(register: cudaq.qview):
     
 @cudaq.kernel           
 #def pe_kernel (num_qubits: int, theta: float, do_uopt: bool):
-def pe_kernel (num_qubits: int, theta: float):
+def pe_kernel (num_qubits: int, theta: float, use_midcircuit_measurement: bool):
     M_PI = 3.1415926536
     
     init_phase = 2 * M_PI * theta

--- a/phase-estimation/pe_benchmark.py
+++ b/phase-estimation/pe_benchmark.py
@@ -112,7 +112,7 @@ def bitstring_to_theta(counts, num_counting_qubits):
 ################ Benchmark Loop
 
 # Execute program with default parameters
-def run(min_qubits=3, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=100,
+def run(min_qubits=3, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=100, use_midcircuit_measurement=False,
 		init_phase=None,
 		backend_id=None, provider_backend=None,
 		hub="ibm-q", group="open", project="main", exec_options=None,
@@ -201,7 +201,7 @@ def run(min_qubits=3, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=100
 			# create the circuit for given qubit size and theta, store time metric
 			mpi.barrier()
 			ts = time.time()
-			qc = PhaseEstimation(num_qubits, theta)
+			qc = PhaseEstimation(num_qubits, theta, use_midcircuit_measurement)
 			metrics.store_metric(num_qubits, theta, 'create_time', time.time() - ts)
 
 			# Store each circuit if we want to return them
@@ -253,6 +253,7 @@ def get_args():
 	parser.add_argument("--init_phase", "-p", default=0.0, help="Input Phase Value", type=float)
 	parser.add_argument("--nonoise", "-non", action="store_true", help="Use Noiseless Simulator")
 	parser.add_argument("--verbose", "-v", action="store_true", help="Verbose")
+	parser.add_argument("--use_midcircuit_measurement", "-mid", action="store_true", help="Use dynamic circuit")
 	return parser.parse_args()
 	
 # if main, execute method
@@ -274,6 +275,7 @@ if __name__ == '__main__':
 		skip_qubits=args.skip_qubits, max_circuits=args.max_circuits,
 		num_shots=args.num_shots,
 		#method=args.method,
+		use_midcircuit_measurement=args.use_midcircuit_measurement,
 		init_phase=args.init_phase,
 		backend_id=args.backend_id,
 		exec_options = {"noise_model" : None} if args.nonoise else {},

--- a/phase-estimation/qiskit/pe_kernel.py
+++ b/phase-estimation/qiskit/pe_kernel.py
@@ -8,18 +8,19 @@ from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 
 # saved subcircuits circuits for printing
 QC_ = None
+QFTDI_ = None
 QFTI_ = None
 U_ = None
 
 ############### Circuit Definition
 
-def PhaseEstimation(num_qubits, theta):
+def PhaseEstimation(num_qubits, theta, use_midcircuit_measurement):
     
     qr = QuantumRegister(num_qubits)
     
     num_counting_qubits = num_qubits - 1 # only 1 state qubit
     
-    cr = ClassicalRegister(num_counting_qubits)
+    cr = ClassicalRegister(num_counting_qubits, name = "c0")
     qc = QuantumCircuit(qr, cr, name=f"qpe-{num_qubits}-{theta}")
 
     # initialize counting qubits in superposition
@@ -44,26 +45,27 @@ def PhaseEstimation(num_qubits, theta):
 
     qc.barrier()
     
-    # inverse quantum Fourier transform only on counting qubits
-    qc.append(inv_qft_gate(num_counting_qubits), qr[:num_counting_qubits])
-    
+    if use_midcircuit_measurement:
+        dynamic_inv_qft = dyn_inv_qft_gate(num_counting_qubits)
+        qc.compose(dynamic_inv_qft, qubits=qr[:num_counting_qubits], clbits = cr[:num_counting_qubits], inplace=True)
+    else:
+        qc.append(inv_qft_gate(num_counting_qubits), qr[:num_counting_qubits])
+
     qc.barrier()
     
     # measure counting qubits
     qc.measure([qr[m] for m in range(num_counting_qubits)], list(range(num_counting_qubits)))
 
     # save smaller circuit example for display
-    global QC_, U_, QFTI_
+    global QC_, U_
     if QC_ == None or num_qubits <= 5:
         if num_qubits < 9: QC_ = qc
     if U_ == None or num_qubits <= 5:
         if num_qubits < 9: U_ = U
-    if QFTI_ == None or num_qubits <= 5:
-        if num_qubits < 9: QFTI_ = inv_qft_gate(num_counting_qubits)
         
     # collapse the 3 sub-circuit levels used in this benchmark (for qiskit)
     qc2 = qc.decompose().decompose().decompose()
-            
+    
     # return a handle on the circuit
     return qc2
 
@@ -106,6 +108,41 @@ def inv_qft_gate(input_size):
     # return a handle on the circuit
     return qc
 
+############### Dynamic Inverse QFT Circuit
+
+def dyn_inv_qft_gate(input_size):
+   
+    global QFTDI_, num_gates, depth
+    qr = QuantumRegister(input_size, name="q_dyn_inv")
+    cr = ClassicalRegister(input_size, name = "c0")
+    qc = QuantumCircuit(qr, cr, name="dyn_inv_qft")
+
+    # mirror the static inv-QFT loop order, but with mid-circuit feed-forward
+    for i_qubit in reversed(range(input_size)):
+        hidx = input_size - 1 - i_qubit
+
+        # H on the “hidx” wire
+        qc.h(qr[hidx])
+        qc.barrier()
+
+        # measure for feed-forward
+        qc.measure(qr[hidx], cr[hidx])
+        qc.barrier()
+
+        # if measured == 1, apply RZ(-θ) on each target
+        if hidx < input_size - 1:
+            for j in reversed(range(i_qubit)):
+                θ = math.pi / (2 ** (i_qubit - j))
+                with qc.if_test((cr[hidx], 1)):
+                    qc.rz(-θ, qr[input_size - 1 - j])
+        qc.barrier()
+
+    # cache a small-size example for printing
+    if QFTDI_ is None and input_size <= 5:
+        QFTDI_ = qc
+
+    return qc
+
 ############### BV Circuit Drawer
 
 # Draw the circuits of this benchmark program
@@ -114,6 +151,10 @@ def kernel_draw():
     # print a sample circuit
     print("Sample Circuit:"); print(QC_ if QC_ != None else "  ... too large!")
     print("\nPhase Operator 'U' = "); print(U_ if U_ != None else "  ... too large!")
-    print("\nInverse QFT Circuit ="); print(QFTI_ if QFTI_ != None else "  ... too large!")
+    if QFTI_ == None:
+        print("\nDynamic Inverse QFT Circuit ="); print(QFTDI_ if QFTDI_ != None else "  ... too large!")
+    else:
+        print("\nInverse QFT Circuit ="); print(QFTI_ if QFTI_ != None else "  ... too large!")
+    
     
     

--- a/quantum-fourier-transform/qiskit/qft_kernel.py
+++ b/quantum-fourier-transform/qiskit/qft_kernel.py
@@ -61,8 +61,9 @@ def QuantumFourierTransform(num_qubits, secret_int,  bitset = None, method=1, us
         
         qc.barrier()
 
-        # if dynamic circuit flag is used, it uses dynamic Inverse QFT, otherwise it 
-        # uses a static Inverse QFT
+        # Uses dynamic inverse QFT if the flag is set; otherwise, use static version.
+        # Dynamic circuits can only be added using "compose" because they are not unitary.
+        # The "append" method requires the added circuit to be unitary, which dynamic circuits are not.
         if use_midcircuit_measurement:
             dynamic_inv_qft = dyn_inv_qft_gate(input_size)
             qc.compose(dynamic_inv_qft, qubits=qr, clbits = cr, inplace=True)
@@ -102,10 +103,10 @@ def QuantumFourierTransform(num_qubits, secret_int,  bitset = None, method=1, us
             num_gates+=1
             
         depth += 1
- 
+        
         if use_midcircuit_measurement:
             dynamic_inv_qft = dyn_inv_qft_gate(input_size)
-            qc.compose(dynamic_inv_qft, qubits=qr, clbits = cr, inplace=True)
+            qc.compose(dynamic_inv_qft, qr[:], clbits = cr, inplace=True)
         else:
             qc.append(inv_qft_gate(input_size).to_instruction(), qr)
         


### PR DESCRIPTION
Implemented Dynamic Circuit (Dynamic Inverse QFT) in the exisiting QPE circuit. If the --use_midcircuit_measurement flag is used, it uses dynamic IQFT instead of regular IQFT.

This also PR also supports the regular QPE benchmark with static IQFT in cudaq.

Note: In this PR, compose method is used instead of append for dynamic circuits because append requires the circuit to be unitary, but dynamic circuits have mid-circuit measurements that doesn't make the circuit unitary. 