### PR TITLE
Getting Quantum-Fourier-Transform Circuits

### DIFF
--- a/quantum-fourier-transform/qft_benchmark.py
+++ b/quantum-fourier-transform/qft_benchmark.py
@@ -137,7 +137,7 @@ def run (min_qubits=2, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=10
         method=1, use_midcircuit_measurement = False, input_value=None,
         backend_id=None, provider_backend=None,
         hub="ibm-q", group="open", project="main", exec_options=None,
-        context=None, api=None):
+        context=None, api=None, get_circuits=False):
 
     # configure the QED-C Benchmark package for use with the given API
     QuantumFourierTransform, kernel_draw = qedc_benchmarks_init(api)
@@ -155,6 +155,10 @@ def run (min_qubits=2, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=10
     
     ##########
     
+    # Variable to store all created circuits to return
+    if get_circuits:
+        all_qcs = {}
+
     # Initialize metrics module
     metrics.init_metrics()
 
@@ -206,7 +210,12 @@ def run (min_qubits=2, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=10
         else:
             sys.exit("Invalid QFT method")
         
-        print(f"************\nExecuting [{num_circuits}] circuits with num_qubits = {num_qubits}")
+        if not get_circuits:
+            print(f"************\nExecuting [{num_circuits}] circuits with num_qubits = {num_qubits}")
+        else:
+            print(f"************\nCreating [{num_circuits}] circuits with num_qubits = {num_qubits}")
+			# Initialize dictionary to store circuits for this qubit group. 
+            all_qcs[str(num_qubits)] = {}
         
         # determine range of secret strings to loop over
         if 2**(input_size) <= max_circuits:
@@ -235,12 +244,23 @@ def run (min_qubits=2, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=10
             qc = QuantumFourierTransform(num_qubits, s_int, bitset, method, use_midcircuit_measurement)       
             metrics.store_metric(input_size, s_int, 'create_time', time.time()-ts)
             
+            # If we only want the circuits:
+            if get_circuits:	
+                all_qcs[str(num_qubits)][str(s_int)] = qc
+                # Continue to skip sumbitting the circuit for execution. 
+                continue
+            
             # submit circuit for execution on target (simulator, cloud simulator, or hardware)
             ex.submit_circuit(qc, input_size, s_int, shots=num_shots)
               
         # Wait for some active circuits to complete; report metrics when groups complete
         ex.throttle_execution(metrics.finalize_group)  
         
+    # Early return if we just want the circuits
+    if get_circuits:
+        print(f"************\nReturning circuits and circuit information")
+        return all_qcs, metrics.circuit_metrics
+
     # Wait for all active circuits to complete; report metrics when groups complete
     ex.finalize_execution(metrics.finalize_group)
        

--- a/quantum-fourier-transform/qft_benchmark.py
+++ b/quantum-fourier-transform/qft_benchmark.py
@@ -214,7 +214,7 @@ def run (min_qubits=2, max_qubits=8, skip_qubits=1, max_circuits=3, num_shots=10
             print(f"************\nExecuting [{num_circuits}] circuits with num_qubits = {num_qubits}")
         else:
             print(f"************\nCreating [{num_circuits}] circuits with num_qubits = {num_qubits}")
-			# Initialize dictionary to store circuits for this qubit group. 
+            # Initialize dictionary to store circuits for this qubit group. 
             all_qcs[str(num_qubits)] = {}
         
         # determine range of secret strings to loop over


### PR DESCRIPTION
### Changes Made:

1. Changed `all_qcs` from a list to a dictionary.
2. Added sub dictionaries to `all_qcs` to match the structure of `metrics.circuit_metrics`.
3. Returning `metrics.circuit_metrics`.

The returned circuits are `dict[str, dict[str, QuantumCircuit]]` and the information is returned as `dict[str, dict[str, dict[str, float]]]`.