### PR TITLE
modify qiskit notebook to use kernel versions of some BMs

### DIFF
--- a/benchmarks-qiskit.ipynb
+++ b/benchmarks-qiskit.ipynb
@@ -144,7 +144,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.insert(1, \"bernstein-vazirani/qiskit\")\n",
+    "sys.path.insert(1, \"bernstein-vazirani\")\n",
     "import bv_benchmark\n",
     "bv_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, skip_qubits=skip_qubits,\n",
     "                max_circuits=max_circuits, num_shots=num_shots,\n",
@@ -169,7 +169,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.insert(1, \"bernstein-vazirani/qiskit\")\n",
+    "sys.path.insert(1, \"bernstein-vazirani\")\n",
     "import bv_benchmark\n",
     "bv_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, skip_qubits=skip_qubits,\n",
     "                max_circuits=max_circuits, num_shots=num_shots,\n",
@@ -192,7 +192,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.insert(1, \"hidden-shift/qiskit\")\n",
+    "sys.path.insert(1, \"hidden-shift\")\n",
     "import hs_benchmark\n",
     "hs_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits,\n",
     "                max_circuits=max_circuits, num_shots=num_shots,\n",
@@ -214,7 +214,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.insert(1, \"quantum-fourier-transform/qiskit\")\n",
+    "sys.path.insert(1, \"quantum-fourier-transform\")\n",
     "import qft_benchmark\n",
     "qft_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, skip_qubits=skip_qubits,\n",
     "                max_circuits=max_circuits, num_shots=num_shots,\n",
@@ -237,7 +237,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.insert(1, \"quantum-fourier-transform/qiskit\")\n",
+    "sys.path.insert(1, \"quantum-fourier-transform\")\n",
     "import qft_benchmark\n",
     "qft_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, skip_qubits=skip_qubits,\n",
     "                max_circuits=max_circuits, num_shots=num_shots,\n",
@@ -282,7 +282,7 @@
    "outputs": [],
    "source": [
     "import sys\n",
-    "sys.path.insert(1, \"phase-estimation/qiskit\")\n",
+    "sys.path.insert(1, \"phase-estimation\")\n",
     "import pe_benchmark\n",
     "pe_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, skip_qubits=skip_qubits,\n",
     "                max_circuits=max_circuits, num_shots=num_shots,\n",
@@ -524,9 +524,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "qiskit-test-1.3",
+   "display_name": "qiskit-test-2.0",
    "language": "python",
-   "name": "qiskit-test-1.3"
+   "name": "qiskit-test-2.0"
   },
   "language_info": {
    "codemirror_mode": {

--- a/quantum-fourier-transform/qiskit/qft_kernel.py
+++ b/quantum-fourier-transform/qiskit/qft_kernel.py
@@ -38,8 +38,7 @@ def QuantumFourierTransform(num_qubits, secret_int,  bitset = None, method=1, us
         qc.barrier()
 
         # perform QFT on the input
-        static_qft_gate = qft_gate(input_size)
-        qc.compose(static_qft_gate, qubits=qr, inplace=True)
+        qc.append(qft_gate(input_size).to_instruction(), qr)
 
 
         # End with Hadamard on all qubits (to measure the z rotations)
@@ -192,7 +191,6 @@ def inv_qft_gate(input_size):
     
     if QFTI_ == None or input_size <= 5:
         if input_size < 9: QFTI_= qc
-        print(QFTI_)
         
     return qc
 


### PR DESCRIPTION
Modify qiskit notebook to use kernel versions of BV, HS, QFT, and QPE
Also, fix kernel draw issues in QFT