### PR TITLE
New imports for BV, PE, HS, and QFT for Cirq and Braket

### DIFF
--- a/benchmarks-braket.ipynb
+++ b/benchmarks-braket.ipynb
@@ -83,9 +83,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"bernstein-vazirani/braket\")\n",
-    "import bv_benchmark\n",
+    "from bernstein_vazirani.braket import bv_benchmark\n",
     "bv_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                backend_id=backend_id)"
    ]
@@ -105,9 +103,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"hidden-shift/braket\")\n",
-    "import hs_benchmark\n",
+    "from hidden_shift.braket import hs_benchmark\n",
     "hs_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots, \n",
     "                backend_id=backend_id)"
    ]
@@ -127,9 +123,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"quantum-fourier-transform/braket\")\n",
-    "import qft_benchmark\n",
+    "from quantum_fourier_transform.braket import qft_benchmark\n",
     "qft_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                method=1,\n",
     "                backend_id=backend_id)"
@@ -150,9 +144,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"quantum-fourier-transform/braket\")\n",
-    "import qft_benchmark\n",
+    "from quantum_fourier_transform.braket import qft_benchmark\n",
     "qft_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                method=2,\n",
     "                backend_id=backend_id)"
@@ -195,9 +187,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"phase-estimation/braket\")\n",
-    "import pe_benchmark\n",
+    "from phase_estimation.braket import pe_benchmark\n",
     "pe_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                backend_id=backend_id)"
    ]

--- a/benchmarks-cirq.ipynb
+++ b/benchmarks-cirq.ipynb
@@ -64,9 +64,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"bernstein-vazirani/cirq\")\n",
-    "import bv_benchmark\n",
+    "from bernstein_vazirani.cirq import bv_benchmark\n",
     "bv_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                 backend_id=backend_id, provider_backend=provider_backend)"
    ]
@@ -86,9 +84,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"hidden-shift/cirq\")\n",
-    "import hs_benchmark\n",
+    "from hidden_shift.cirq import hs_benchmark\n",
     "hs_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                 backend_id=backend_id, provider_backend=provider_backend)"
    ]
@@ -108,9 +104,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"quantum-fourier-transform/cirq\")\n",
-    "import qft_benchmark\n",
+    "from quantum_fourier_transform.cirq import qft_benchmark\n",
     "qft_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                method=1,\n",
     "                backend_id=backend_id, provider_backend=provider_backend)"
@@ -131,9 +125,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"quantum-fourier-transform/cirq\")\n",
-    "import qft_benchmark\n",
+    "from quantum_fourier_transform.cirq import qft_benchmark\n",
     "qft_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                method=2,\n",
     "                backend_id=backend_id, provider_backend=provider_backend)"
@@ -176,9 +168,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"phase-estimation/cirq\")\n",
-    "import pe_benchmark\n",
+    "from phase_estimation.cirq import pe_benchmark\n",
     "pe_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                backend_id=backend_id, provider_backend=provider_backend)"
    ]

--- a/bernstein_vazirani/braket/bv_benchmark.py
+++ b/bernstein_vazirani/braket/bv_benchmark.py
@@ -2,16 +2,13 @@
 Bernstein-Vazirani Benchmark Program - Braket
 """
 
-import sys
 import time
 
 from braket.circuits import Circuit      # AWS imports: Import Braket SDK modules
 import numpy as np
 
-sys.path[1:1] = [ "_common", "_common/braket" ]
-sys.path[1:1] = [ "../../_common", "../../_common/braket" ]
-import execute as ex
-import metrics as metrics
+from _common.braket import execute as ex
+from _common import metrics as metrics
 
 np.random.seed(0)
 

--- a/bernstein_vazirani/cirq/bv_benchmark.py
+++ b/bernstein_vazirani/cirq/bv_benchmark.py
@@ -3,17 +3,14 @@ Bernstein-Vazirani Benchmark Program - Cirq
 """
 
 from collections import defaultdict
-import sys
 import time
 
 import cirq
 import numpy as np
 
-sys.path[1:1] = [ "_common", "_common/cirq" ]
-sys.path[1:1] = [ "../../_common", "../../_common/cirq" ]
-import cirq_utils as cirq_utils
-import execute as ex
-import metrics as metrics
+from _common.cirq import cirq_utils as cirq_utils
+from _common.cirq import execute as ex
+from _common import metrics as metrics
 
 np.random.seed(0)
 

--- a/hidden_shift/braket/hs_benchmark.py
+++ b/hidden_shift/braket/hs_benchmark.py
@@ -2,16 +2,13 @@
 Hidden Shift Benchmark Program - Braket
 """
 
-import sys
 import time
 
 from braket.circuits import Circuit     # AWS imports: Import Braket SDK modules
 import numpy as np
 
-sys.path[1:1] = [ "_common", "_common/braket" ]
-sys.path[1:1] = [ "../../_common", "../../_common/braket" ]
-import execute as ex
-import metrics as metrics
+from _common.braket import execute as ex
+from _common import metrics as metrics
 
 np.random.seed(0)
 

--- a/hidden_shift/cirq/hs_benchmark.py
+++ b/hidden_shift/cirq/hs_benchmark.py
@@ -3,17 +3,14 @@ Hidden-Shift Benchmark Program - Cirq
 """
 
 from collections import defaultdict
-import sys
 import time
 
 import cirq
 import numpy as np
 
-sys.path[1:1] = ["_common", "_common/cirq"]
-sys.path[1:1] = ["../../_common", "../../_common/cirq"]
-import cirq_utils as cirq_utils
-import execute as ex
-import metrics as metrics
+from _common.cirq import cirq_utils as cirq_utils
+from _common.cirq import execute as ex
+from _common import metrics as metrics
 
 np.random.seed()
 

--- a/phase_estimation/braket/pe_benchmark.py
+++ b/phase_estimation/braket/pe_benchmark.py
@@ -3,16 +3,13 @@ Phase Estimation Benchmark Program - Braket
 """
 
 import time
-import sys
 
 from braket.circuits import Circuit     # AWS imports: Import Braket SDK modules
 import numpy as np
 
-sys.path[1:1] = ["_common", "_common/braket", "quantum-fourier-transform/braket"]
-sys.path[1:1] = ["../../_common", "../../_common/braket", "../../quantum-fourier-transform/braket"]
-import execute as ex
-import metrics as metrics
-from qft_benchmark import inv_qft_gate
+from _common.braket import execute as ex
+from _common import metrics as metrics
+from quantum_fourier_transform.braket.qft_benchmark import inv_qft_gate
 
 np.random.seed(0)
 

--- a/phase_estimation/cirq/pe_benchmark.py
+++ b/phase_estimation/cirq/pe_benchmark.py
@@ -3,18 +3,15 @@ Phase Estimation Benchmark Program - Cirq
 """
 
 from collections import defaultdict
-import sys
 import time
 
 import cirq
 import numpy as np
 
-sys.path[1:1] = ["_common", "_common/cirq", "quantum-fourier-transform/cirq"]
-sys.path[1:1] = ["../../_common", "../../_common/cirq", "../../quantum-fourier-transform/cirq"]
-import cirq_utils as cirq_utils
-import execute as ex
-import metrics as metrics
-from qft_benchmark import inv_qft_gate
+from _common.cirq import cirq_utils as cirq_utils
+from _common.cirq import execute as ex
+from _common import metrics as metrics
+from quantum_fourier_transform.cirq.qft_benchmark import inv_qft_gate
 
 np.random.seed(0)
 

--- a/quantum_fourier_transform/braket/qft_benchmark.py
+++ b/quantum_fourier_transform/braket/qft_benchmark.py
@@ -2,17 +2,14 @@
 Quantum Fourier Transform Benchmark Program - Braket
 """
 
-import sys
 import time
 
 from braket.circuits import Circuit     # AWS imports: Import Braket SDK modules
 import math
 import numpy as np
 
-sys.path[1:1] = [ "_common", "_common/braket" ]
-sys.path[1:1] = [ "../../_common", "../../_common/braket" ]
-import execute as ex
-import metrics as metrics
+from _common.braket import execute as ex
+from _common import metrics as metrics
 
 np.random.seed(0)
 

--- a/quantum_fourier_transform/cirq/qft_benchmark.py
+++ b/quantum_fourier_transform/cirq/qft_benchmark.py
@@ -4,17 +4,14 @@ Quantum Fourier Transform Benchmark Program - Cirq
 
 from collections import defaultdict
 import math
-import sys
 import time
 
 import cirq
 import numpy as np
 
-sys.path[1:1] = [ "_common", "_common/cirq" ]
-sys.path[1:1] = [ "../../_common", "../../_common/cirq" ]
-import cirq_utils as cirq_utils
-import execute as ex
-import metrics as metrics
+from _common.cirq import cirq_utils as cirq_utils
+from _common.cirq import execute as ex
+from _common import metrics as metrics
 
 np.random.seed(0)
 


### PR DESCRIPTION
### Description
The mentioned benchmarks only use the new package structure for Qiskit and CUDA-Q; this PR extends their package structure to Cirq and Braket -- updating their respective notebooks as well. Moving forward in this manner will allow for a smooth merge into master at the end. 

### Testing

- All benchmarks executed in _benchmarks-cirq.ipynb_. 
- Assumed functionality in Braket.