### PR TITLE
New Imports for DJ, Grover's, and AE

### DIFF
--- a/amplitude_estimation/cirq/ae_benchmark.py
+++ b/amplitude_estimation/cirq/ae_benchmark.py
@@ -4,18 +4,15 @@ Amplitude Estimation Benchmark Program via Phase Estimation - Cirq
 
 from collections import defaultdict
 import copy
-import sys
 import time
 
 import cirq
 import numpy as np
 
-sys.path[1:1] = ["_common", "_common/cirq", "quantum-fourier-transform/cirq"]
-sys.path[1:1] = ["../../_common", "../../_common/cirq", "../../quantum-fourier-transform/cirq"]
-import cirq_utils as cirq_utils
-import execute as ex
-import metrics as metrics
-from qft_benchmark import inv_qft_gate
+from _common.cirq import cirq_utils as cirq_utils
+from _common.cirq import execute as ex
+from _common import metrics as metrics
+from quantum_fourier_transform.cirq.qft_benchmark import inv_qft_gate
 
 np.random.seed(0)
 

--- a/amplitude_estimation/qiskit/ae_benchmark.py
+++ b/amplitude_estimation/qiskit/ae_benchmark.py
@@ -3,17 +3,14 @@ Amplitude Estimation Benchmark Program via Phase Estimation - Qiskit
 """
 
 import copy
-import sys
 import time
 
 import numpy as np
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 
-sys.path[1:1] = ["_common", "_common/qiskit", "quantum-fourier-transform/qiskit"]
-sys.path[1:1] = ["../../_common", "../../_common/qiskit", "../../quantum-fourier-transform/qiskit"]
-import execute as ex
-import metrics as metrics
-from qft_benchmark import inv_qft_gate
+from _common.qiskit import execute as ex
+from _common import metrics as metrics
+from quantum_fourier_transform.qiskit.qft_benchmark import inv_qft_gate
 
 # Benchmark Name
 benchmark_name = "Amplitude Estimation"

--- a/benchmarks-braket.ipynb
+++ b/benchmarks-braket.ipynb
@@ -61,9 +61,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"deutsch-jozsa/braket\")\n",
-    "import dj_benchmark\n",
+    "from deutsch_jozsa.braket import dj_benchmark\n",
     "dj_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                backend_id=backend_id)"
    ]
@@ -173,9 +171,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"grovers/braket\")\n",
-    "import grovers_benchmark  \n",
+    "from grovers.braket import grovers_benchmark  \n",
     "grovers_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                backend_id=backend_id)"
    ]

--- a/benchmarks-cirq.ipynb
+++ b/benchmarks-cirq.ipynb
@@ -42,9 +42,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"deutsch-jozsa/cirq\")\n",
-    "import dj_benchmark\n",
+    "from deutsch_jozsa.cirq import dj_benchmark\n",
     "dj_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                 backend_id=backend_id, provider_backend=provider_backend)"
    ]
@@ -154,9 +152,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"grovers/cirq\")\n",
-    "import grovers_benchmark\n",
+    "from grovers.cirq import grovers_benchmark\n",
     "grovers_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                backend_id=backend_id, provider_backend=provider_backend)"
    ]
@@ -198,9 +194,7 @@
    },
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"amplitude-estimation/cirq\")\n",
-    "import ae_benchmark\n",
+    "from amplitude_estimation.cirq import ae_benchmark\n",
     "ae_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, max_circuits=max_circuits, num_shots=num_shots,\n",
     "                backend_id=backend_id, provider_backend=provider_backend)"
    ]

--- a/benchmarks-qiskit.ipynb
+++ b/benchmarks-qiskit.ipynb
@@ -247,9 +247,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"grovers/qiskit\")\n",
-    "import grovers_benchmark\n",
+    "from grovers.qiskit import grovers_benchmark\n",
     "grovers_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, skip_qubits=skip_qubits,\n",
     "                max_circuits=max_circuits, num_shots=num_shots,\n",
     "                backend_id=backend_id, provider_backend=provider_backend,\n",
@@ -315,9 +313,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import sys\n",
-    "sys.path.insert(1, \"amplitude-estimation/qiskit\")\n",
-    "import ae_benchmark\n",
+    "from amplitude_estimation.qiskit import ae_benchmark\n",
     "ae_benchmark.run(min_qubits=min_qubits, max_qubits=max_qubits, skip_qubits=skip_qubits,\n",
     "                max_circuits=max_circuits, num_shots=num_shots,\n",
     "                backend_id=backend_id, provider_backend=provider_backend,\n",

--- a/deutsch_jozsa/braket/dj_benchmark.py
+++ b/deutsch_jozsa/braket/dj_benchmark.py
@@ -2,16 +2,13 @@
 Deutsch-Jozsa Benchmark Program - Braket
 """
 
-import sys
 import time
 
 from braket.circuits import Circuit     # AWS imports: Import Braket SDK modules
 import numpy as np
 
-sys.path[1:1] = [ "_common", "_common/braket" ]
-sys.path[1:1] = [ "../../_common", "../../_common/braket" ]
-import execute as ex
-import metrics as metrics
+from _common.braket import execute as ex
+from _common import metrics as metrics
 
 np.random.seed(0)
 

--- a/deutsch_jozsa/cirq/dj_benchmark.py
+++ b/deutsch_jozsa/cirq/dj_benchmark.py
@@ -3,17 +3,14 @@ Deutsch-Jozsa Benchmark Program - Cirq
 """
 
 from collections import defaultdict
-import sys
 import time
 
 import cirq
 import numpy as np
 
-sys.path[1:1] = ["_common", "_common/cirq"]
-sys.path[1:1] = ["../../_common", "../../_common/cirq"]
-import cirq_utils as cirq_utils
-import execute as ex
-import metrics as metrics
+from _common.cirq import cirq_utils as cirq_utils
+from _common.cirq import execute as ex
+from _common import metrics as metrics
 
 np.random.seed(0)
 

--- a/deutsch_jozsa/qiskit/dj_benchmark.py
+++ b/deutsch_jozsa/qiskit/dj_benchmark.py
@@ -2,16 +2,13 @@
 Deutsch-Jozsa Benchmark Program - Qiskit
 """
 
-import sys
 import time
 
 import numpy as np
 from qiskit import QuantumCircuit, QuantumRegister, ClassicalRegister
 
-sys.path[1:1] = [ "_common", "_common/qiskit" ]
-sys.path[1:1] = [ "../../_common", "../../_common/qiskit" ]
-import execute as ex
-import metrics as metrics
+from _common.qiskit import execute as ex
+from _common import metrics as metrics
 
 # Benchmark Name
 benchmark_name = "Deutsch-Jozsa"

--- a/grovers/braket/grovers_benchmark.py
+++ b/grovers/braket/grovers_benchmark.py
@@ -2,16 +2,13 @@
 Grover's Search Benchmark Program - Braket
 """
 
-import sys
 import time
 
 from braket.circuits import Circuit  # AWS imports: Import Braket SDK modules
 import numpy as np
 
-sys.path[1:1] = [ "_common", "_common/braket" ]
-sys.path[1:1] = [ "../../_common", "../../_common/braket" ]
-import execute as ex
-import metrics as metrics
+from _common.braket import execute as ex
+from _common import metrics as metrics
 
 np.random.seed(0)
 

--- a/grovers/cirq/grovers_benchmark.py
+++ b/grovers/cirq/grovers_benchmark.py
@@ -3,17 +3,14 @@ Grover's Search Benchmark Program - Cirq
 """
 
 from collections import defaultdict
-import sys
 import time
 
 import cirq
 import numpy as np
 
-sys.path[1:1] = ["_common", "_common/cirq"]
-sys.path[1:1] = ["../../_common", "../../_common/cirq"]
-import cirq_utils as cirq_utils
-import execute as ex
-import metrics as metrics
+from _common.cirq import cirq_utils as cirq_utils
+from _common.cirq import execute as ex
+from _common import metrics as metrics
 
 np.random.seed(0)
 

--- a/grovers/qiskit/grovers_benchmark.py
+++ b/grovers/qiskit/grovers_benchmark.py
@@ -3,15 +3,12 @@ Grover's Search Benchmark Program
 (C) Quantum Economic Development Consortium (QED-C) 2024.
 '''
 
-import sys
 import time
 
 import numpy as np
 
-sys.path[1:1] = ["_common", "_common/qiskit"]
-sys.path[1:1] = ["../../_common", "../../_common/qiskit"]
-import execute as ex
-import metrics as metrics
+from _common.qiskit import execute as ex
+from _common import metrics as metrics
 
 from grovers_kernel import GroversSearch, kernel_draw, _use_mcx_shim
 

--- a/grovers/qiskit/grovers_benchmark.py
+++ b/grovers/qiskit/grovers_benchmark.py
@@ -10,7 +10,7 @@ import numpy as np
 from _common.qiskit import execute as ex
 from _common import metrics as metrics
 
-from grovers_kernel import GroversSearch, kernel_draw, _use_mcx_shim
+from grovers.qiskit.grovers_kernel import GroversSearch, kernel_draw, _use_mcx_shim
 
 # Benchmark Name
 benchmark_name = "Grover's Search"


### PR DESCRIPTION
### Description
The mentioned benchmarks (Deutsch Jozsa, Grover's, and Amplitude Estimation) use the package structure instead of `sys.path()` for their imports.  Their respective notebooks have also been updated.  

### Testing
- All benchmarks executed in _benchmarks-qiskit.ipynb_.
- All benchmarks executed in _benchmarks-cirq.ipynb_. 
- Assumed functionality in Braket.