### PR TITLE
Use `exec_options` to pass backend-specific arguments to CUDA-Q's `set_target`

### DIFF
--- a/bernstein-vazirani/bv_benchmark.py
+++ b/bernstein-vazirani/bv_benchmark.py
@@ -246,6 +246,7 @@ def get_args():
 	parser.add_argument("--input_value", "-i", default=None, help="Fixed Input Value", type=int)
 	parser.add_argument("--nonoise", "-non", action="store_true", help="Use Noiseless Simulator")
 	parser.add_argument("--verbose", "-v", action="store_true", help="Verbose")
+	parser.add_argument("--exec_options", "-e", default=None, help="Additional execution options to be passed to the backend", type=str)
 	return parser.parse_args()
 	
 # if main, execute method
@@ -269,7 +270,7 @@ if __name__ == '__main__':
 		method=args.method,
 		input_value=args.input_value,
 		backend_id=args.backend_id,
-		exec_options = {"noise_model" : None} if args.nonoise else {},
+		exec_options = {"noise_model" : None} if args.nonoise else args.exec_options,
 		api=args.api
 		)
    

--- a/hamlib/hamlib_simulation_benchmark.py
+++ b/hamlib/hamlib_simulation_benchmark.py
@@ -1334,6 +1334,7 @@ def get_args():
     parser.add_argument("--nodraw", "-nod", action="store_true", help="Do not draw circuit diagram")
     parser.add_argument("--data_suffix", "-suffix", default=None, help="Suffix appended to data file name", type=str)
     parser.add_argument("--profile", "-prof", action="store_true", help="Profile with cProfile") 
+    parser.add_argument("--exec_options", "-e", default=None, help="Additional execution options to be passed to the backend", type=str) 
     return parser.parse_args()
     
 def parse_name_value_pairs(input_string: str) -> Dict[str, str]:
@@ -1379,7 +1380,7 @@ def do_run(args):
         plot_results=not args.noplot,
         draw_circuits=not args.nodraw,
         backend_id=args.backend_id,
-        exec_options = {"noise_model" : None} if args.nonoise else {},
+        exec_options = {"noise_model" : None} if args.nonoise else args.exec_options,
         api=args.api
         )
 

--- a/hidden-shift/hs_benchmark.py
+++ b/hidden-shift/hs_benchmark.py
@@ -226,6 +226,7 @@ def get_args():
 	parser.add_argument("--input_value", "-i", default=None, help="Fixed Input Value", type=int)
 	parser.add_argument("--nonoise", "-non", action="store_true", help="Use Noiseless Simulator")
 	parser.add_argument("--verbose", "-v", action="store_true", help="Verbose")
+	parser.add_argument("--exec_options", "-e", default=None, help="Additional execution options to be passed to the backend", type=str)
 	return parser.parse_args()
 	
 # if main, execute method
@@ -249,7 +250,7 @@ if __name__ == '__main__':
 		method=args.method,
 		input_value=args.input_value,
 		backend_id=args.backend_id,
-		exec_options = {"noise_model" : None} if args.nonoise else {},
+		exec_options = {"noise_model" : None} if args.nonoise else args.exec_options,
 		api=args.api
 		)
    

--- a/phase-estimation/pe_benchmark.py
+++ b/phase-estimation/pe_benchmark.py
@@ -257,6 +257,7 @@ def get_args():
 	parser.add_argument("--nonoise", "-non", action="store_true", help="Use Noiseless Simulator")
 	parser.add_argument("--verbose", "-v", action="store_true", help="Verbose")
 	parser.add_argument("--use_midcircuit_measurement", "-mid", action="store_true", help="Use dynamic circuit")
+	parser.add_argument("--exec_options", "-e", default=None, help="Additional execution options to be passed to the backend", type=str)
 	return parser.parse_args()
 	
 # if main, execute method
@@ -281,7 +282,7 @@ if __name__ == '__main__':
 		use_midcircuit_measurement=args.use_midcircuit_measurement,
 		init_phase=args.init_phase,
 		backend_id=args.backend_id,
-		exec_options = {"noise_model" : None} if args.nonoise else {},
+		exec_options = {"noise_model" : None} if args.nonoise else args.exec_options,
 		api=args.api
 		)
    

--- a/quantum-fourier-transform/qft_benchmark.py
+++ b/quantum-fourier-transform/qft_benchmark.py
@@ -294,6 +294,7 @@ def get_args():
     parser.add_argument("--nonoise", "-non", action="store_true", help="Use Noiseless Simulator")
     parser.add_argument("--verbose", "-v", action="store_true", help="Verbose")
     parser.add_argument("--use_midcircuit_measurement", "-mid", action="store_true", help="Use dynamic circuit")
+    parser.add_argument("--exec_options", "-e", default=None, help="Additional execution options to be passed to the backend", type=str)
     return parser.parse_args()
     
 # if main, execute method
@@ -318,7 +319,7 @@ if __name__ == '__main__':
         use_midcircuit_measurement=args.use_midcircuit_measurement,
         input_value=args.input_value,
         backend_id=args.backend_id,
-        exec_options = {"noise_model" : None} if args.nonoise else {},
+        exec_options = {"noise_model" : None} if args.nonoise else args.exec_options,
         api=args.api
         )
    


### PR DESCRIPTION
This PR introduces support for passing additional backend execution options to benchmark scripts. The CUDA-Q backend setup logic in `_common/cudaq/execute.py` has also been updated to handle these options, including robust parsing and validation.

* Added `--exec_options` argument to the argument parsers in the following benchmark scripts, allowing users to specify additional backend options as a JSON string and updated the logic to forward the user-supplied options instead of an empty dictionary:
  1.  `bv_benchmark.py`,
  2.  `hamlib_simulation_benchmark.py`, 
  3. `hs_benchmark.py`, 
  4. `pe_benchmark.py`, 
  5. `qft_benchmark.py`

* Modified `_common/cudaq/execute.py` to parse `exec_options` as JSON, validate key/value types, and gracefully fall back to defaults if parsing fails.
* Imported the `json` module in `_common/cudaq/execute.py` to support parsing of execution options. `set_target` method
