### PR TITLE
Modify arguments used to specify parallel execution in cudaq

### DIFF
--- a/_common/cudaq/execute.py
+++ b/_common/cudaq/execute.py
@@ -37,10 +37,9 @@ import cudaq
 
 verbose = False
 
-# Parallel execution configuration
+# Parallel execution configuration (reserved for future use)
 _parallel_config = {
-    "mode": None,
-    "num_gpus": 0,
+    "gpus_per_circuit": None,
     "initialized": False
 }
 
@@ -52,12 +51,12 @@ _parallel_config = {
 # Each MPI rank executes a subset of circuits on its assigned GPU.
 #
 # REQUIREMENTS:
-# - Launch with: mpiexec -np N python -m mpi4py script.py -pm mpi
+# - Launch with: mpiexec -np N python -m mpi4py script.py -gpc 1
 # - GPU binding must be set externally (Slurm --gpus-per-task=1 or CUDA_VISIBLE_DEVICES)
 # - Each rank should see exactly ONE GPU
 #
 # NOTE: This is DIFFERENT from mgpu mode (which pools GPUs for one large circuit).
-# When parallel_mode="mpi", we override mgpu and use single-GPU per rank.
+# When gpus_per_circuit=1, we override mgpu and use single-GPU per rank.
 ###################################################################
 
 def _get_block_indices(total_items: int, num_workers: int) -> list:
@@ -852,8 +851,7 @@ def execute_circuits_immed(
         backend_id: str = None,
         circuits: list = None,
         num_shots: int = 100,
-        parallel_mode: str = "sequential",
-        num_gpus: int = None
+        gpus_per_circuit: int = None
     ) -> list:
     """
     Execute a list of circuits on the given backend with the given number of shots.
@@ -862,19 +860,17 @@ def execute_circuits_immed(
         backend_id: Backend identifier (currently unused for cudaq)
         circuits: List of [kernel, params] circuit tuples
         num_shots: Number of shots per circuit
-        parallel_mode: Execution mode:
-            - "sequential": Execute circuits one at a time (default)
-            - "mpi": Distribute circuits across MPI ranks (requires -m mpi4py launch)
-            - "mqpu": NOT IMPLEMENTED - falls back to sequential
-            - "auto": NOT IMPLEMENTED - falls back to sequential
-        num_gpus: Number of GPUs (currently unused, reserved for future)
+        gpus_per_circuit: Number of GPUs to pool per circuit.
+            None = use all available GPUs together (mgpu if MPI, single GPU if not).
+            1 = each GPU runs one circuit independently (max parallelism, requires MPI).
+            M = M GPUs pool per circuit, P/M circuits in parallel (requires MPI, not yet implemented).
 
     Returns:
         ExecutionResult object with get_counts() method
     """
 
     if verbose:
-        print(f"... execute_circuits_immed({backend_id}, {len(circuits)}, {num_shots}, mode={parallel_mode})")
+        print(f"... execute_circuits_immed({backend_id}, {len(circuits)}, {num_shots}, gpus_per_circuit={gpus_per_circuit})")
 
     # Handle empty case
     if not circuits or len(circuits) == 0:
@@ -882,20 +878,23 @@ def execute_circuits_immed(
 
     counts_array = None
 
-    # Explicit parallel circuit distribution mode
-    if parallel_mode == "mpi":
-        counts_array = _execute_parallel_mpi(circuits, num_shots)
-        # Returns None if MPI not available or only 1 rank - fall through to sequential
+    # Determine execution strategy based on gpus_per_circuit
+    if gpus_per_circuit is not None and mpi.enabled() and mpi.size > 1:
+        if gpus_per_circuit == 1:
+            # Mode 3: each GPU runs one circuit independently (max parallelism)
+            counts_array = _execute_parallel_mpi(circuits, num_shots)
+            # Returns None if MPI not available or only 1 rank - fall through to sequential
+        elif gpus_per_circuit < mpi.size:
+            # Mode 4: hybrid — M GPUs pool per circuit, P/M circuits in parallel
+            # TODO: Developer adds _execute_parallel_hybrid(circuits, num_shots, gpus_per_circuit)
+            if mpi.rank == 0:
+                print(f"... WARNING: gpus_per_circuit={gpus_per_circuit} (hybrid mode) not yet implemented, using default execution")
+        # else gpus_per_circuit >= mpi.size: same as default, use all GPUs together
 
-    # Warn about unimplemented modes
-    if parallel_mode == "mqpu":
-        print(f"... WARNING: parallel_mode='mqpu' not implemented, using sequential")
-    elif parallel_mode == "auto":
-        print(f"... WARNING: parallel_mode='auto' not implemented, using sequential")
-
-    # Sequential/mgpu execution (default)
-    # When MPI is enabled without -pm mpi, this uses mgpu mode (set in set_execution_target)
-    # for state vector distribution - all ranks participate in each circuit execution
+    # Default: sequential/mgpu execution
+    # When MPI is enabled, this uses mgpu mode (set in set_execution_target)
+    # for state vector distribution - all ranks participate in each circuit execution.
+    # When MPI is not enabled, this runs on a single GPU.
     if counts_array is None:
         counts_array = []
         for circuit in circuits:

--- a/_common/qiskit/execute.py
+++ b/_common/qiskit/execute.py
@@ -1674,14 +1674,13 @@ def execute_circuits_immed(
         backend_id: str = None,
         circuits: list = None,
         num_shots: int = 100,
-        parallel_mode: str = "sequential",
-        num_gpus: int = None
+        gpus_per_circuit: int = None
     ) -> list:
     """
     Execute a list of circuits on the given backend with the given number of shots.
 
-    Note: parallel_mode and num_gpus are accepted for API compatibility with cudaq
-    but are ignored in the qiskit implementation.
+    Note: gpus_per_circuit is accepted for API compatibility with cudaq
+    but is ignored in the qiskit implementation.
     """
     
     if verbose:

--- a/_doc/release_notes.md
+++ b/_doc/release_notes.md
@@ -1,0 +1,23 @@
+# Release Notes
+
+The **QED-C Application-Oriented Benchmarks** suite is continually evolving, with issues fixed and enhancements made to add features.
+This section presents a brief record of relevant changes made to each version that has been released. Latest version is at the top.
+
+### Release 1.2.1 - 13 April 2026
+
+- **Refactor of API-specific Execution Logic** This set of changes consolidated and normalized the result object returned from execution of a quantum circuit across all APIs.  The ExecutionResult object provides the get_counts() method which returns a dictionary of measurment results.  The counts dict can be populated in serverl methods unique to the API.
+
+### Release 1.2.0 - 11 April 2026
+
+- **Added Support for Parallel Circuit Execution** The Hamlib benchmark on CUDA-Q now supports an execution mode in which a subset of circuits generated for the selected Hamiltonian simulation are executed in parallel in order to reduce the total execution time.
+
+### Release 1.1.0 - 25 January 2026
+
+- **Completed Refactoring of API-specific kernel Files** All benchmarks are now structured so that API-specific code, e.g for Qiskit or CUDA-Q, is contained in a correspondingly named sub-directory. The primary benchmark file resides at the benchmark directory level and is API-agnostic.  The --app (-a) command line argument is used to specify the name of the API, cudaq or qiskit, from which the appropriate kernel code will be dynamically imported.
+
+### Release 1.0.0 - Prior to 12 November 2025
+
+- **Multiple Years of Development and Testing** Since 2019, QED-C has been working to develop, test, and polish the complete set of benchmark programs.
+
+<br>
+&nbsp;&copy;&nbsp;2025 Quantum Economic Development Consortium (QED-C). All Rights Reserved.

--- a/_doc/release_notes.md
+++ b/_doc/release_notes.md
@@ -3,8 +3,10 @@
 The **QED-C Application-Oriented Benchmarks** suite is continually evolving, with issues fixed and enhancements made to add features.
 This section presents a brief record of relevant changes made to each version that has been released. Latest version is at the top.
 
-### Release 1.2.1 - 13 April 2026
+### Release 1.2.1 - 14 April 2026
 
+- **Parallel Execution Logic modifed to use GPU Cluster Size** The pair of options that was implemented earlier to support parallel execution of circuits in hamlib has been modifed. The options **--parallel_mode** and **--num_gpus** have been removed and replaced with the **--gpus_per_cluster (-gpc)** option, which indicates the number of GPUs that cluster together to execute a single circuit. E.g., if you have 16 GPUs and set -gpc to 1, then you could execute 16 circuits in parallel. with 1 GPU used for each execution. The default is to use ALL GPUs in a cluster if MPI is enabled. This is the option which provides more qubits by distributing the state vector across all of the GPUs. The "hybrid" mode in which you might set -gpc to a number other than 1 is not yet implemented.
+    
 - **Refactor of API-specific Execution Logic** This set of changes consolidated and normalized the result object returned from execution of a quantum circuit across all APIs.  The ExecutionResult object provides the get_counts() method which returns a dictionary of measurment results.  The counts dict can be populated in serverl methods unique to the API.
 
 ### Release 1.2.0 - 11 April 2026

--- a/hamlib/_common/execute_enhanced.py
+++ b/hamlib/_common/execute_enhanced.py
@@ -19,8 +19,7 @@ def execute_circuits_enhanced(
         distribute_shots: bool = False,
         pauli_term_groups: list = None,
         ds_method: str = 'max_sq',
-        parallel_mode: str = "sequential",
-        num_gpus: int = None,
+        gpus_per_circuit: int = None,
         verbose: bool = False,
     ) -> list:
     """
@@ -31,8 +30,9 @@ def execute_circuits_enhanced(
     and according to the ds_method (default = 'max_sq').
 
     Args:
-        parallel_mode: Execution mode for cudaq - "sequential", "mqpu", "mpi", or "auto"
-        num_gpus: Number of GPUs to use for parallel execution (None = auto-detect)
+        gpus_per_circuit: Number of GPUs to pool per circuit (None = use all available).
+            1 = each GPU runs independently (max parallelism).
+            M = M GPUs pool per circuit, P/M circuits in parallel.
     """
     if verbose:
         for circuit, group in list(zip(circuits, pauli_term_groups)):
@@ -48,8 +48,7 @@ def execute_circuits_enhanced(
                 backend_id = backend_id,
                 circuits = circuits,
                 num_shots = int(num_shots / len(circuits)),
-                parallel_mode = parallel_mode,
-                num_gpus = num_gpus
+                gpus_per_circuit = gpus_per_circuit
                 )
     else:
         # execute with shots distributed by weight of coefficients
@@ -59,8 +58,7 @@ def execute_circuits_enhanced(
                 num_shots = num_shots,
                 groups = pauli_term_groups,
                 ds_method = ds_method,
-                parallel_mode = parallel_mode,
-                num_gpus = num_gpus,
+                gpus_per_circuit = gpus_per_circuit,
                 verbose = verbose,
                 )
 
@@ -77,8 +75,7 @@ def execute_circuits_distribute_shots(
         num_shots: int = 100,
         groups: list = None,
         ds_method: str = 'max_sq',
-        parallel_mode: str = "sequential",
-        num_gpus: int = None,
+        gpus_per_circuit: int = None,
         verbose: bool = False,
     ) -> list:
 
@@ -141,8 +138,7 @@ def execute_circuits_distribute_shots(
         backend_id = backend_id,
         circuits_list = circuits_list,
         num_shots_list = bucket_avg_shots,
-        parallel_mode = parallel_mode,
-        num_gpus = num_gpus,
+        gpus_per_circuit = gpus_per_circuit,
         )
 
     # Create a flattened list of all groups
@@ -206,8 +202,7 @@ def execute_circuits_with_mixed_shots(
         backend_id: str = None,
         circuits_list: list = None,
         num_shots_list: List[int] = None,
-        parallel_mode: str = "sequential",
-        num_gpus: int = None,
+        gpus_per_circuit: int = None,
     ):
 
     # Loop over the circuit lists associated with each bucket
@@ -225,8 +220,7 @@ def execute_circuits_with_mixed_shots(
                 #circuits = [circuit],
                 circuits = circuits,
                 num_shots = num_shots,
-                parallel_mode = parallel_mode,
-                num_gpus = num_gpus
+                gpus_per_circuit = gpus_per_circuit
                 )
 
         # accumulate list of returned raw count dicts to parallel the group list

--- a/hamlib/hamlib_simulation_benchmark.py
+++ b/hamlib/hamlib_simulation_benchmark.py
@@ -287,8 +287,7 @@ def run(min_qubits: int = 2,
         api = None,
         warmup = False,
         get_circuits = False,
-        parallel_mode: str = "sequential",
-        num_gpus: int = None):
+        gpus_per_circuit: int = None):
     """
     Execute program with default parameters.
 
@@ -683,8 +682,7 @@ def run(min_qubits: int = 2,
                                 num_shots = num_shots,
                                 distribute_shots = distribute_shots,
                                 pauli_term_groups = pauli_term_groups,
-                                parallel_mode = parallel_mode,
-                                num_gpus = num_gpus,
+                                gpus_per_circuit = gpus_per_circuit,
                                 verbose = verbose
                                 )
 
@@ -721,8 +719,7 @@ def run(min_qubits: int = 2,
                                 num_shots = num_shots,
                                 distribute_shots = distribute_shots,
                                 pauli_term_groups = pauli_term_groups,
-                                parallel_mode = parallel_mode,
-                                num_gpus = num_gpus,
+                                gpus_per_circuit = gpus_per_circuit,
                                 verbose = verbose
                                 )
 
@@ -1127,8 +1124,7 @@ def get_args():
     parser.add_argument("--data_suffix", "-suffix", default=None, help="Suffix appended to data file name", type=str)
     parser.add_argument("--profile", "-prof", action="store_true", help="Profile with cProfile")
     parser.add_argument("--exec_options", "-e", default=None, help="Additional execution options to be passed to the backend", type=str)
-    parser.add_argument("--parallel_mode", "-pm", default="sequential", help="Parallel execution mode: sequential, mqpu, mpi, auto", type=str)
-    parser.add_argument("--num_gpus", "-ng", default=None, help="Number of GPUs for parallel execution (auto-detect if not specified)", type=int)
+    parser.add_argument("--gpus_per_circuit", "-gpc", default=None, help="Number of GPUs to pool per circuit (None=all available, 1=max parallelism, M=M GPUs per circuit)", type=int)
     return parser.parse_args()
     
 def parse_name_value_pairs(input_string: str) -> Dict[str, str]:
@@ -1176,8 +1172,7 @@ def do_run(args):
         backend_id=args.backend_id,
         exec_options = {"noise_model" : None} if args.nonoise else args.exec_options,
         api=args.api, warmup=args.warmup,
-        parallel_mode=args.parallel_mode,
-        num_gpus=args.num_gpus
+        gpus_per_circuit=args.gpus_per_circuit
         )
 
 import cProfile


### PR DESCRIPTION
The pair of options that was implemented earlier to support parallel execution of circuits in hamlib has been modifed. The options **--parallel_mode** and **--num_gpus** have been removed and replaced with the **--gpus_per_cluster (-gpc)** option, which indicates the number of GPUs that cluster together to execute a single circuit. E.g., if you have 16 GPUs and set -gpc to 1, then you could execute 16 circuits in parallel. with 1 GPU used for each execution. The default is to use ALL GPUs in a cluster if MPI is enabled. This is the option which provides more qubits by distributing the state vector across all of the GPUs. The "hybrid" mode in which you might set -gpc to a number other than 1 is not yet implemented.