### PR TITLE
Fix IBM credentials: read API token from environment, not just saved …

### DIFF
--- a/qedcbench/run_all.py
+++ b/qedcbench/run_all.py
@@ -116,13 +116,17 @@ def configure_backend(backend_id, run_args):
     # IBM backends: "ibm" for least-busy, or specific like "ibm_sherbrooke"
     if backend_id.startswith("ibm"):
         ibm_instance = os.environ.get("IBM_INSTANCE", "")
+        ibm_token = os.environ.get("IBM_API_TOKEN", None)
         if not ibm_instance:
             print("  WARNING: IBM_INSTANCE not set — will use saved default credentials.")
             print("  Set IBM_INSTANCE to your CRN or service name to target a specific plan.")
+        elif not ibm_token:
+            print("  WARNING: IBM_INSTANCE is set but IBM_API_TOKEN is not — using saved token.")
+            print("  If using a different account, set both IBM_API_TOKEN and IBM_INSTANCE.")
 
         if backend_id == "ibm":
             from qiskit_ibm_runtime import QiskitRuntimeService
-            service = QiskitRuntimeService(channel="ibm_cloud", instance=ibm_instance)
+            service = QiskitRuntimeService(channel="ibm_cloud", token=ibm_token, instance=ibm_instance)
             backend = service.least_busy(simulator=False, operational=True, min_num_qubits=100)
             backend_id = backend.name
             print(f"  Least-busy IBM backend: {backend_id}")

--- a/qedclib/qiskit/execute.py
+++ b/qedclib/qiskit/execute.py
@@ -472,8 +472,14 @@ def set_execution_target(backend_id='qasm_simulator',
             backend_name = backend_id
             primitive_name = "sampler"
 
+            # Use token from environment if available, otherwise fall back to saved account
+            ibm_token = os.environ.get("IBM_API_TOKEN", None)
+            if instance and not ibm_token:
+                print("  WARNING: IBM_INSTANCE is set but IBM_API_TOKEN is not — using saved token.")
+                print("  If using a different account, set both IBM_API_TOKEN and IBM_INSTANCE.")
+
             try:
-                service = QiskitRuntimeService(channel=channel, instance=instance)
+                service = QiskitRuntimeService(channel=channel, token=ibm_token, instance=instance)
                 backend = service.backend(backend_name)
 
                 # DEVNOTE : If dynamic circuit is enabled in the exec_options, then If Else Operation
@@ -485,6 +491,11 @@ def set_execution_target(backend_id='qasm_simulator',
                 ######@@@@@@@@@@@@###########
 
             except Exception as ex:
+                if "403" in str(ex) or "Forbidden" in str(ex):
+                    print(f"ERROR: IBM credentials rejected (403 Forbidden) for {backend_id}.")
+                    print("  Check that IBM_API_TOKEN and IBM_INSTANCE match the same account.")
+                    print("  Also verify saved credentials: QiskitRuntimeService.saved_accounts(channel='ibm_cloud')")
+                    raise RuntimeError(f"IBM authentication failed for {backend_id} — 403 Forbidden") from None
                 print(authentication_error_msg.format(backend_id))
                 raise ex
             print(f"... using {backend=} {primitive_name=}")


### PR DESCRIPTION
…account

  IBM_INSTANCE was read from env but the token always came from saved credentials,
  causing 403 errors when switching accounts. Now both configure_backend and
  set_execution_target read IBM_API_TOKEN from the environment. Warns when
  instance is set without a token, and catches 403 errors with a clear message.