### PR TITLE
Fix backend switching and cloud simulator batching

### DIFF
--- a/qedclib/qiskit/execute.py
+++ b/qedclib/qiskit/execute.py
@@ -333,9 +333,14 @@ def set_execution_target(backend_id='qasm_simulator',
     if exec_options is None:
         exec_options = {}
 
+    # Reset session state from any previous backend (prevents stale IBM sampler/session
+    # from being used when switching to a different backend like IonQ or qasm_simulator)
+    sampler = None
+    session = None
+
     # set M3 options
     use_m3 = exec_options.get("use_m3", False)
-        
+
     # if a custom provider backend is given, use it ...
     # Note: in this case, the backend_id is an identifier that shows up in plots
     if provider_backend != None:

--- a/server/app.py
+++ b/server/app.py
@@ -238,8 +238,10 @@ async def start_run(req: RunRequest):
             "plot_results": False,
         }
 
-        # Use batch_size=1 for simulators so cancel can take effect between circuits
-        if "simulator" in req.backend_id or req.backend_id == "nvidia":
+        # Use batch_size=1 for local simulators so cancel can take effect between circuits
+        # (don't apply to cloud simulators like ionq_simulator where batching matters)
+        local_simulators = ["qasm_simulator", "statevector_simulator", "aer_sampler", "statevector_sampler", "nvidia"]
+        if req.backend_id in local_simulators:
             run_args["max_batch_size"] = 1
 
         # Configure hardware backend


### PR DESCRIPTION
  Reset sampler and session to None at the top of set_execution_target so
  stale IBM state doesn't leak into subsequent runs on other backends
  (e.g. IonQ, qasm_simulator). Also restrict max_batch_size=1 to local
  simulators only — cloud backends like ionq_simulator need full batching.